### PR TITLE
fix(blocking-review): require line-level evidence for regression BLOCKs

### DIFF
--- a/.github/workflows/claude-blocking-review.yml
+++ b/.github/workflows/claude-blocking-review.yml
@@ -72,6 +72,9 @@ jobs:
 
             Use the repository's CLAUDE.md for guidance on style and conventions.
             Be constructive and specific — cite file names and line numbers where possible.
+            When listing non-blocking observations, order them by maintenance impact:
+            issues that will predictably cause test drift or duplicated bugs should
+            appear before stylistic or organizational notes.
 
             ${{ inputs.extra_instructions != '' && format('---\n\nAdditional instructions for this repository:\n\n{0}', inputs.extra_instructions) || '' }}
 
@@ -99,6 +102,25 @@ jobs:
             - Documentation gaps
             - Code organization suggestions
             - Informational warnings
+
+            EVIDENCE STANDARD FOR RELIABILITY REGRESSION BLOCKs:
+
+            You cannot run the test suite. When claiming a test will fail or a code
+            path will regress, you must trace the execution path from entry point to
+            the specific assertion or failure point, with line-number citations at each
+            step. If your trace relies on assumed execution order you have not verified
+            in the diff or source, downgrade to PASS with a named observation instead.
+
+              ❌ "validateEntitlements() is now called before CLAUDE_API_KEY is checked,
+                 so the 503 test will fail." → Requires verifying actual call order. If
+                 you cannot cite the lines proving that order, issue PASS.
+
+              ✓ "Line 42 calls foo(), which at line 71 sets X to null; the assertion at
+                 line 265 expects X to be non-null — that assertion will fail." → BLOCK.
+
+              ✓ "The test fixture at line 48 does not set REVENUECAT_API_SECRET, but the
+                 handler reads it at line 89 and returns early if absent — the test will
+                 never reach the code path it claims to exercise." → BLOCK.
 
             When uncertain between BLOCK and PASS, default to PASS.
 


### PR DESCRIPTION
## Summary

- **Evidence standard for regression BLOCKs**: When the reviewer claims a test or code path will regress, it must now trace the execution path to a specific failing assertion with line citations. If the trace relies on assumed execution order not verified in the diff or source, it must downgrade to PASS + observation instead of issuing a BLOCK.
- **Observation ordering**: Non-blocking observations should lead with highest maintenance-impact items (things that will cause test drift or duplicate bugs) before stylistic notes.

## Motivation

Based on observed false positives from PR #841/#842 (2026-02-25):

- The reviewer issued a BLOCK claiming a 503 test would fail because `validateEntitlements()` was called before `CLAUDE_API_KEY` was checked — the actual code order was the opposite. Three CI round-trips wasted.
- Root cause: the reviewer inferred execution order rather than tracing the actual call path in the source.
- The reviewer cannot run tests (`claude_args` restricts tools to `gh pr diff`, `gh pr view`, `cat`, `echo`, `tee`), so confidence about test failures must come from traceable code analysis.

The examples in the new EVIDENCE STANDARD section are drawn directly from the incident, making them concrete anchors rather than abstract rules.

## Test plan

- [ ] Review the prompt changes in the workflow file for correctness
- [ ] Confirm the ❌/✓ examples accurately reflect the intended policy
- [ ] Confirm no structural changes to the verdict mechanism (Steps 1–4 unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)