### PR TITLE
fix(claude-assistant): prevent startup_failure by making secret optional

### DIFF
--- a/.github/workflows/claude-assistant.yml
+++ b/.github/workflows/claude-assistant.yml
@@ -22,7 +22,7 @@ on:
     secrets:
       claude_oauth_token:
         description: 'Claude Code OAuth token (CLAUDE_CODE_OAUTH_TOKEN secret)'
-        required: true
+        required: false
 
 jobs:
   run:


### PR DESCRIPTION
## Root Cause

`claude-assistant.yml` declared `claude_oauth_token` as `required: true`. GitHub validates `required: true` secrets at **workflow dispatch time** — before any jobs run. This means every run that triggers the `claude.yml` workflow (even when `@claude` isn't mentioned) hits this validation gate and gets reported as `startup_failure`, with zero jobs started (`jobs: []`).

This was traced by examining kebab-tax run history:
- Runs #1–1847: `skipped` (inline `claude.yml`, no `required:` constraint)
- Run #1848+: `startup_failure` (switched to `claude-assistant.yml@v1` with `required: true`)

The gate-job pattern (PR kebab-tax#908) didn't help because the secret is validated at dispatch time, before job conditions are evaluated.

## Fix

`required: false` — GitHub skips dispatch-time secret validation. If `@claude` is triggered and the secret is genuinely missing, the Claude Code action fails at runtime with a clear authentication error. For non-`@claude` runs, the calling job is properly skipped.

## Test Plan

- [ ] After merging and moving `v1` tag: verify kebab-tax runs for non-`@claude` events show `skipped` (not `startup_failure`)
- [ ] Verify kebab-tax runs for `@claude` events still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)