### PR TITLE
fix(claude-assistant): remove actions: read from GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/claude-assistant.yml
+++ b/.github/workflows/claude-assistant.yml
@@ -13,6 +13,11 @@ name: Claude Code Assistant
 #         (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
 #         (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)) ||
 #         (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association))
+#       permissions:
+#         contents: read
+#         issues: read
+#         pull-requests: read
+#         id-token: write # required by claude-code-action for internal authentication
 #       uses: smartwatermelon/github-workflows/.github/workflows/claude-assistant.yml@v1
 #       secrets:
 #         claude_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/claude-assistant.yml
+++ b/.github/workflows/claude-assistant.yml
@@ -31,7 +31,6 @@ jobs:
       contents: read
       pull-requests: read
       issues: read
-      actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -17,6 +17,11 @@ jobs:
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association))
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
+      id-token: write # required by claude-code-action for internal authentication
     uses: smartwatermelon/github-workflows/.github/workflows/claude-assistant.yml@v1
     secrets:
       claude_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Root cause

`claude-assistant.yml` requested `actions: read` in its `permissions:` block. This permission is **not** included in GitHub's default read-only GITHUB_TOKEN scope. When a reusable workflow requests a scope the caller cannot provide, GitHub fails the entire run with `startup_failure` before creating any jobs — producing zero check runs and no log output.

This affected every consumer repo that deployed the thin caller (all 9 repos), causing all `Claude Code` workflow runs to fail silently with `startup_failure`.

## Changes

### `claude-assistant.yml`
- **Remove `actions: read` from `permissions:`** — this was the root cause of `startup_failure`
- Claude still reads CI results via `additional_permissions: actions: read` passed to `claude-code-action`, which handles it through the action's own authentication, not GITHUB_TOKEN
- Update usage comment to show callers should include an explicit `permissions:` block

### `claude.yml` (this repo's own thin caller)
- **Add explicit `permissions:` block** — addresses security/code-scanning alert #1 (`actions/missing-workflow-permissions`)
- Includes `id-token: write` required by `claude-code-action` for internal authentication

## After merge

1. Advance `v1` tag to HEAD — all consumer repos pick up the fix automatically via `@v1`
2. Update 9 consumer repos' `claude.yml` thin callers to add the `permissions:` block (addresses the same scanner finding across all repos)

🤖 Generated with [Claude Code](https://claude.com/claude-code)