### PR TITLE
fix(claude-assistant): add id-token: write to reusable workflow permissions

### DIFF
--- a/.github/workflows/claude-assistant.yml
+++ b/.github/workflows/claude-assistant.yml
@@ -36,6 +36,7 @@ jobs:
       contents: read
       pull-requests: read
       issues: read
+      id-token: write # required by claude-code-action for internal authentication
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4


### PR DESCRIPTION
## Problem

After PR #12 removed `actions: read` (which fixed `startup_failure`), the action now fails at the OIDC token fetch step:

```
Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?
```

## Root cause

The reusable workflow's `permissions:` block overrides the caller's permissions — it doesn't inherit them. `id-token: write` was only added to the caller (`claude.yml`) in PR #12, but it must also be present in `claude-assistant.yml`'s job-level `permissions:` block for `claude-code-action` to obtain an OIDC token.

`id-token: write` does **not** cause `startup_failure` (unlike `actions: read`) — it's a standard permission supported in reusable workflows.

## Change

Add `id-token: write` to the `permissions:` block in `claude-assistant.yml`.

## After merge

Advance `v1` tag to HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)