### PR TITLE
chore: rename workflow to Claude Blocking Review

### DIFF
--- a/.github/workflows/claude-blocking-review.yml
+++ b/.github/workflows/claude-blocking-review.yml
@@ -1,4 +1,4 @@
-name: Claude Blocking Code Review
+name: Claude Blocking Review
 
 # Reusable workflow: blocks PR merges when Claude finds bugs, reliability
 # regressions, security issues, or data-loss risks.
@@ -16,7 +16,7 @@ name: Claude Blocking Code Review
 #         claude_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 #
 # The calling job name ("claude-review" above) becomes the required status
-# check name: "Claude Code Review / claude-review" in branch protection.
+# check name: "Claude Blocking Review / claude-review / run-review" in branch protection.
 #
 # Escape hatch: add [skip-claude-review: reason] to the PR body to bypass
 # enforcement with an audit trail.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,4 +1,4 @@
-name: Claude Code Review
+name: Claude Blocking Review
 
 # Example caller workflow for claude-blocking-review.yml.
 # Copy this file into your repository's .github/workflows/ directory,
@@ -10,7 +10,7 @@ name: Claude Code Review
 # Prerequisites:
 #   1. CLAUDE_CODE_OAUTH_TOKEN secret available (repo or org level)
 #   2. (Optional) Branch protection rule requiring status check:
-#      "Claude Code Review / claude-review / run-review"
+#      "Claude Blocking Review / claude-review / run-review"
 
 permissions:
   contents: read

--- a/docs/plans/2026-03-20-migrate-all-repos-to-blocking-review.md
+++ b/docs/plans/2026-03-20-migrate-all-repos-to-blocking-review.md
@@ -94,7 +94,7 @@ jobs:
 **After** (blocking review caller, ~20 lines):
 
 ```yaml
-name: Claude Code Review
+name: Claude Blocking Review
 
 permissions:
   contents: read
@@ -216,7 +216,7 @@ git checkout -b "$BRANCH" origin/main
 
 # 1. Replace claude-code-review.yml
 cat > .github/workflows/claude-code-review.yml << 'WORKFLOW'
-name: Claude Code Review
+name: Claude Blocking Review
 
 permissions:
   contents: read
@@ -322,7 +322,7 @@ After each PR is merged:
 The migration changes the status check name:
 
 - **Old** (plugin-based): `Claude Code Review / claude-review` (from step ID)
-- **New** (reusable workflow): `Claude Code Review / claude-review / run-review`
+- **New** (reusable workflow): `Claude Blocking Review / claude-review / run-review`
 
 Any existing branch protection referencing the old check name must be updated.
 Repos without branch protection for reviews should have it added.
@@ -340,7 +340,7 @@ CURRENT=$(gh api repos/OWNER/REPO/branches/main/protection 2>/dev/null || echo "
 
 # The script should handle both cases:
 #   1. Remove old check name if present
-#   2. Add new check name: "Claude Code Review / claude-review / run-review"
+#   2. Add new check name: "Claude Blocking Review / claude-review / run-review"
 #   3. Preserve all other existing checks and settings
 ```
 
@@ -371,7 +371,7 @@ means a broken review never blocks merges permanently.
 
 - All 19 repos use `claude-blocking-review.yml@v1` for code review
 - All 19 repos use `claude-assistant.yml@v1` for @claude interactions
-- All 19 repos have branch protection requiring `Claude Code Review / claude-review / run-review`
+- All 19 repos have branch protection requiring `Claude Blocking Review / claude-review / run-review`
 - No review takes >4 minutes or >6 turns on a typical PR
 - Review cost per PR < $0.15 (down from potential $1+)
 - No regressions in existing CI workflows


### PR DESCRIPTION
## Summary

Rename the workflow from "Claude Blocking Code Review" / "Claude Code Review" to **"Claude Blocking Review"** to disambiguate from Anthropic's generic Claude Code Review check.

New required status check name: `Claude Blocking Review / claude-review / run-review`

## Changes

- `claude-blocking-review.yml`: `name:` updated
- `claude-code-review.yml`: `name:` and comment references updated
- Migration plan: all status check references updated

## Test plan

- [ ] After merge + v1 tag update, verify new check name appears on next PR
- [ ] Update branch protection rules to reference new check name

🤖 Generated with [Claude Code](https://claude.com/claude-code)