### PR TITLE
feat: add .claude-review-ignore for excluding repos from audit

### DIFF
--- a/.claude-review-ignore
+++ b/.claude-review-ignore
@@ -1,0 +1,8 @@
+# Repos excluded from Claude Blocking Review.
+# One per line: owner/repo
+# Lines starting with # are comments. Blank lines are ignored.
+#
+# The audit script (claude-review-audit.sh) skips these repos entirely.
+# Use this for repos that should never have the review installed.
+
+nightowlstudiollc/network-agent

--- a/README.md
+++ b/README.md
@@ -157,3 +157,8 @@ reports gaps but makes no changes.
 ```
 
 Requires: `gh` CLI (authenticated), `jq`, `bash` 4.0+.
+
+### Excluding repos
+
+Add repos to `.claude-review-ignore` (one `owner/repo` per line) to skip them
+in audits. Useful for repos that should never have the review installed.

--- a/claude-review-audit.sh
+++ b/claude-review-audit.sh
@@ -26,6 +26,7 @@ declare -A OWNER_TYPES=(
 )
 OWNERS=("smartwatermelon" "nightowlstudiollc")
 TARGET_SECRET="CLAUDE_CODE_OAUTH_TOKEN"
+IGNORE_FILE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/.claude-review-ignore"
 VERBOSE="${1:-}"
 if [[ -n "${VERBOSE}" && "${VERBOSE}" != "--verbose" ]]; then
   printf "Warning: unrecognized argument '%s'. Usage: ./%s [--verbose]\n" \
@@ -38,9 +39,21 @@ fail() { printf "  ❌ %s\n" "${*}"; }
 warn() { printf "  ⚠️  %s\n" "${*}"; }
 info() { [[ "${VERBOSE}" == "--verbose" ]] && printf "  ℹ  %s\n" "${*}" || true; }
 
+# ── load ignore list ───────────────────────────────────────────────────────────
+declare -A IGNORED_REPOS=()
+if [[ -f "${IGNORE_FILE}" ]]; then
+  while IFS= read -r line; do
+    line="${line%%#*}" # strip inline comments
+    line="${line// /}" # strip whitespace
+    [[ -z "${line}" ]] && continue
+    IGNORED_REPOS["${line}"]=1
+  done <"${IGNORE_FILE}"
+fi
+
 # ── global accumulators ─────────────────────────────────────────────────────────
 declare -a REPOS_WITH_ISSUES=()
 declare -a ISSUE_LINES=()
+declare -a SKIPPED_REPOS=()
 TOTAL_REPOS=0
 TOTAL_ISSUES=0
 
@@ -355,6 +368,11 @@ for owner in "${OWNERS[@]}"; do
 
   while IFS= read -r repo; do
     [[ -z "${repo}" ]] && continue
+    if [[ -n "${IGNORED_REPOS["${owner}/${repo}"]:-}" ]]; then
+      SKIPPED_REPOS+=("${owner}/${repo}")
+      [[ "${VERBOSE}" == "--verbose" ]] && printf "  ⏭  %s/%s (in .claude-review-ignore)\n" "${owner}" "${repo}"
+      continue
+    fi
     check_repo "${owner}" "${repo}"
   done <<<"${repos}"
 done
@@ -364,6 +382,7 @@ printf "\n\n══════════════════════�
 printf "  FINAL SUMMARY\n"
 printf "══════════════════════════════════════════════════════════\n"
 printf "  Repos scanned    : %d\n" "${TOTAL_REPOS}"
+printf "  Repos ignored    : %d\n" "${#SKIPPED_REPOS[@]}"
 printf "  Repos with issues: %d\n" "${#REPOS_WITH_ISSUES[@]}"
 printf "  Total issues     : %d\n" "${TOTAL_ISSUES}"
 
@@ -378,6 +397,13 @@ else
   printf "\n  All issues by repo:\n"
   for line in "${ISSUE_LINES[@]}"; do
     printf "    • %s\n" "${line}"
+  done
+fi
+
+if [[ "${#SKIPPED_REPOS[@]}" -gt 0 ]]; then
+  printf "\n  ⏭  Ignored repos (.claude-review-ignore):\n"
+  for r in "${SKIPPED_REPOS[@]}"; do
+    printf "    - %s\n" "${r}"
   done
 fi
 


### PR DESCRIPTION
## Summary
- Adds `.claude-review-ignore` file (like `.gitignore`) for repos that should never have Claude Blocking Review
- Audit script reads the ignore list and skips matching repos, reporting them in the summary
- `nightowlstudiollc/network-agent` added as first excluded repo

## Test plan
- [ ] Run `./claude-review-audit.sh --verbose` and verify `network-agent` is listed as skipped
- [ ] Verify other repos still audit normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)