### PR TITLE
fix: correct repo name in .claude-review-ignore

### DIFF
--- a/.claude-review-ignore
+++ b/.claude-review-ignore
@@ -5,4 +5,4 @@
 # The audit script (claude-review-audit.sh) skips these repos entirely.
 # Use this for repos that should never have the review installed.
 
-nightowlstudiollc/network-agent
+nightowlstudiollc/networth-agent


### PR DESCRIPTION
## Summary
- Fixes typo: `network-agent` → `networth-agent`

🤖 Generated with [Claude Code](https://claude.com/claude-code)