### PR TITLE
fix: raise max_turns and timeout defaults for large PRs

### DIFF
--- a/.github/workflows/claude-blocking-review.yml
+++ b/.github/workflows/claude-blocking-review.yml
@@ -40,15 +40,15 @@ on:
         required: false
         default: ''
       max_turns:
-        description: 'Maximum Claude API turns (prevents runaway exploration). Default: 6.'
+        description: 'Maximum Claude API turns (prevents runaway exploration). Default: 20.'
         type: number
         required: false
-        default: 6
+        default: 20
       timeout_minutes:
-        description: 'Hard timeout for the Claude review step in minutes. Default: 4.'
+        description: 'Hard timeout for the Claude review step in minutes. Default: 10.'
         type: number
         required: false
-        default: 4
+        default: 10
       model:
         description: 'Claude model ID. Default: claude-sonnet-4-6.'
         type: string


### PR DESCRIPTION
## Summary
- Bumps `max_turns` default from 6 to 20 — large PRs (2000+ line diffs) were exhausting the turn limit before Claude could finish reviewing, causing reviews to silently pass without completing
- Bumps `timeout_minutes` default from 4 to 10 — proportional increase so the full turn budget is usable
- The timeout remains the hard cost guard; unused turns cost nothing

Triggered by: nightowlstudiollc/kebab-tax#1133 review hitting the 6-turn limit on a 2146-line diff

## Test plan
- [ ] Verify CI passes on this PR
- [ ] After merge, update `v1` tag and confirm a large PR review completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)