### PR TITLE
fix: convert timeout_minutes step output to number

### DIFF
--- a/.github/workflows/claude-blocking-review.yml
+++ b/.github/workflows/claude-blocking-review.yml
@@ -189,7 +189,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        timeout-minutes: ${{ steps.estimate.outputs.timeout_minutes }}
+        timeout-minutes: ${{ fromJSON(steps.estimate.outputs.timeout_minutes) }}
         continue-on-error: true  # infrastructure failure must not block merges
         uses: anthropics/claude-code-action@v1
         with:


### PR DESCRIPTION
## Summary
- Wraps `steps.estimate.outputs.timeout_minutes` with `fromJSON()` to convert string → number
- GitHub Actions step outputs are always strings, but `timeout-minutes` requires a number type
- Without this, the workflow fails at template parsing: `Unexpected value '14'`

Follow-up to #27.

## Test plan
- [ ] CI passes
- [ ] After merge + v1 tag update, re-trigger kebab-tax #1133 review

🤖 Generated with [Claude Code](https://claude.com/claude-code)