### PR TITLE
fix: scale turn estimation by model (haiku needs more turns)

### DIFF
--- a/.github/workflows/claude-blocking-review.yml
+++ b/.github/workflows/claude-blocking-review.yml
@@ -5,7 +5,7 @@ name: Claude Blocking Review
 #
 # By default, review parameters are auto-estimated from the PR diff size:
 #   - Model: haiku for ≤500-line diffs, sonnet for larger diffs
-#   - max_turns: scaled from diff size with 20% buffer (min 6, max 50)
+#   - max_turns: scaled from diff size with 20% buffer (min 6–8 by model, max 50)
 #   - timeout: scaled from max_turns (min 4m, max 30m)
 # Callers can override any parameter explicitly.
 #
@@ -148,18 +148,24 @@ jobs:
           fi
 
           # --- Turn estimation ---
-          # Base: 4 turns (read diff, review, post comment, write verdict)
-          # +1 turn per ~150 lines of diff (file reads, reasoning)
-          # +20% buffer, minimum 6
+          # Haiku uses more turns per unit of work than Sonnet, so scale accordingly.
+          # Sonnet: base 4, +1 per 150 lines. Haiku: base 6, +1 per 100 lines.
+          # +20% buffer on top, minimum 8 (haiku) or 6 (sonnet).
           if [ "$MAX_TURNS_INPUT" -gt 0 ]; then
             MAX_TURNS="$MAX_TURNS_INPUT"
             echo "max_turns override: $MAX_TURNS"
           else
-            ESTIMATED=$((4 + DIFF_LINES / 150))
+            if echo "$MODEL" | grep -q "haiku"; then
+              ESTIMATED=$((6 + DIFF_LINES / 100))
+              MIN_TURNS=8
+            else
+              ESTIMATED=$((4 + DIFF_LINES / 150))
+              MIN_TURNS=6
+            fi
             MAX_TURNS=$(( (ESTIMATED * 120 + 99) / 100 ))
-            if [ "$MAX_TURNS" -lt 6 ]; then MAX_TURNS=6; fi
+            if [ "$MAX_TURNS" -lt "$MIN_TURNS" ]; then MAX_TURNS="$MIN_TURNS"; fi
             if [ "$MAX_TURNS" -gt 50 ]; then MAX_TURNS=50; fi
-            echo "Estimated turns: $ESTIMATED → with 20% buffer: $MAX_TURNS"
+            echo "Estimated turns: $ESTIMATED → with 20% buffer: $MAX_TURNS (min $MIN_TURNS)"
           fi
 
           # --- Timeout estimation ---

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Review parameters are estimated automatically from the PR diff size:
 | Parameter | Logic | Range |
 |-----------|-------|-------|
 | **Model** | Haiku for ≤500-line diffs, Sonnet for larger | `claude-haiku-4-5` / `claude-sonnet-4-6` |
-| **Max turns** | `4 + diff_lines/150`, +20% buffer | 6–50 |
+| **Max turns** | Sonnet: `4 + lines/150`; Haiku: `6 + lines/100`, +20% buffer | 6–50 (min 8 for Haiku) |
 | **Timeout** | `turns × 30s × 1.2` | 4–30 minutes |
 
 Callers can override any parameter:


### PR DESCRIPTION
## Summary
- Haiku uses more turns per unit of work than Sonnet — the previous formula was Sonnet-calibrated and left Haiku exhausting turns on even 105-line diffs
- New per-model scaling:
  - **Sonnet:** base 4, +1 per 150 lines, min 6 (unchanged)
  - **Haiku:** base 6, +1 per 100 lines, min 8
- Updated docs (header comment + README) to reflect model-specific estimation

Triggered by: kebab-tax review (105-line diff) exhausting 6 turns with Haiku.

### Example estimates
| Diff | Model | Estimated | Buffered |
|------|-------|-----------|----------|
| 105 lines | Haiku | 7 | 9 |
| 500 lines | Haiku | 11 | 14 |
| 2146 lines | Sonnet | 18 | 22 |

## Test plan
- [ ] CI passes
- [ ] After merge + v1 tag update, trigger kebab-tax review — should allocate ~9 turns for Haiku

🤖 Generated with [Claude Code](https://claude.com/claude-code)