### PR TITLE
fix: raise turn estimation base to account for review overhead

### DIFF
--- a/.github/workflows/claude-blocking-review.yml
+++ b/.github/workflows/claude-blocking-review.yml
@@ -5,7 +5,7 @@ name: Claude Blocking Review
 #
 # By default, review parameters are auto-estimated from the PR diff size:
 #   - Model: haiku for ≤500-line diffs, sonnet for larger diffs
-#   - max_turns: scaled from diff size with 20% buffer (min 6–8 by model, max 50)
+#   - max_turns: scaled from diff size with 20% buffer (min 8–12 by model, max 50)
 #   - timeout: scaled from max_turns (min 4m, max 30m)
 # Callers can override any parameter explicitly.
 #
@@ -148,19 +148,23 @@ jobs:
           fi
 
           # --- Turn estimation ---
-          # Haiku uses more turns per unit of work than Sonnet, so scale accordingly.
-          # Sonnet: base 4, +1 per 150 lines. Haiku: base 6, +1 per 100 lines.
-          # +20% buffer on top, minimum 8 (haiku) or 6 (sonnet).
+          # A review has fixed overhead (~7 tool calls: read diff, read files,
+          # reason, write review, append verdict, post comment, write verdict file).
+          # Haiku splits steps more than Sonnet, so it needs a higher base and
+          # steeper per-line scaling.
+          # Sonnet: base 6, +1 per 150 lines, min 8.
+          # Haiku:  base 10, +1 per 80 lines, min 12.
+          # +20% buffer on top of the estimate.
           if [ "$MAX_TURNS_INPUT" -gt 0 ]; then
             MAX_TURNS="$MAX_TURNS_INPUT"
             echo "max_turns override: $MAX_TURNS"
           else
             if echo "$MODEL" | grep -q "haiku"; then
-              ESTIMATED=$((6 + DIFF_LINES / 100))
-              MIN_TURNS=8
+              ESTIMATED=$((10 + DIFF_LINES / 80))
+              MIN_TURNS=12
             else
-              ESTIMATED=$((4 + DIFF_LINES / 150))
-              MIN_TURNS=6
+              ESTIMATED=$((6 + DIFF_LINES / 150))
+              MIN_TURNS=8
             fi
             MAX_TURNS=$(( (ESTIMATED * 120 + 99) / 100 ))
             if [ "$MAX_TURNS" -lt "$MIN_TURNS" ]; then MAX_TURNS="$MIN_TURNS"; fi

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Review parameters are estimated automatically from the PR diff size:
 | Parameter | Logic | Range |
 |-----------|-------|-------|
 | **Model** | Haiku for ≤500-line diffs, Sonnet for larger | `claude-haiku-4-5` / `claude-sonnet-4-6` |
-| **Max turns** | Sonnet: `4 + lines/150`; Haiku: `6 + lines/100`, +20% buffer | 6–50 (min 8 for Haiku) |
+| **Max turns** | Sonnet: `6 + lines/150`; Haiku: `10 + lines/80`, +20% buffer | 8–50 (min 12 for Haiku) |
 | **Timeout** | `turns × 30s × 1.2` | 4–30 minutes |
 
 Callers can override any parameter:


### PR DESCRIPTION
## Summary
- A review has ~7 fixed tool calls regardless of diff size. Previous base (4/6) was too low — a 105-line Haiku review exhausted 9 turns without posting a comment.
- New formula:
  - **Sonnet:** base 6 + 1/150 lines, min 8 (was 4, min 6)
  - **Haiku:** base 10 + 1/80 lines, min 12 (was 6, min 8)
- Tested locally against known CI outcomes before pushing

### Estimates with new formula
| Diff | Model | Estimated turns |
|------|-------|----------------|
| 50 lines | Haiku | 12 |
| 105 lines | Haiku | 14 |
| 500 lines | Haiku | 20 |
| 500 lines | Sonnet | 11 |
| 2146 lines | Sonnet | 24 |

## Test plan
- [ ] CI passes
- [ ] After merge + v1 tag, trigger kebab-tax review and verify completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)