### PR TITLE
fix: add Read and printf to allowed review tools

### DIFF
--- a/.github/workflows/claude-blocking-review.yml
+++ b/.github/workflows/claude-blocking-review.yml
@@ -291,7 +291,7 @@ jobs:
             The verdict file (Step 4) is the primary signal read by CI. The verdict line
             appended to the comment (Step 2) is the fallback. Both must match.
 
-          claude_args: '--max-turns ${{ steps.estimate.outputs.max_turns }} --model ${{ steps.estimate.outputs.model }} --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(echo *),Bash(cat *),Bash(tee *)"'
+          claude_args: '--max-turns ${{ steps.estimate.outputs.max_turns }} --model ${{ steps.estimate.outputs.model }} --allowed-tools "Read,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(echo *),Bash(cat *),Bash(tee *),Bash(printf *)"'
 
       - name: Check review verdict
         if: always()


### PR DESCRIPTION
## Summary

**Root cause found** by reproducing the review locally with `--no-session-persistence` and the exact CI tool restrictions:

Without `Read`, Claude uses `gh api + base64 -d` for file reads (2+ turns per file). Without `printf`, multi-line file writes via `echo`/`cat`/`tee` are unreliable — Claude burned 8+ turns trying different write approaches for `/tmp/review.md`.

Adding `Read` (native file reading) and `Bash(printf *)` (reliable formatting) drops the review from **17+ turns to ~14** on the same 105-line kebab-tax PR. Combined with the 25-turn floor, this provides ample headroom.

**Important:** The kebab-tax PR #1137 failures at 12 and 25 turns were re-runs of a stale cached workflow (run 24262322985). GitHub Actions caches the workflow definition at trigger time — re-runs use the cached version. A **fresh trigger** (new push to the PR branch) is needed to pick up this fix.

## Test plan
- [ ] CI passes
- [ ] After merge + v1 tag, push commit to kebab-tax PR to get FRESH trigger (not re-run)
- [ ] Review should complete in ~14 turns with 25 allocated

🤖 Generated with [Claude Code](https://claude.com/claude-code)