### PR TITLE
fix: match documented [skip-claude-review: reason] form in grep

### DIFF
--- a/.github/workflows/claude-blocking-review.yml
+++ b/.github/workflows/claude-blocking-review.yml
@@ -300,10 +300,13 @@ jobs:
           PR_NUMBER: ${{ inputs.pr_number }}
           CLAUDE_OUTCOME: ${{ steps.claude-review.outcome }}
         run: |
-          # Escape hatch: [skip-claude-review: reason] in PR body bypasses enforcement
+          # Escape hatch: [skip-claude-review] or [skip-claude-review: reason] in PR body
+          # bypasses enforcement. The extended regex matches both the bare token and the
+          # documented `: reason` form advertised by our error messages. See issue #38
+          # for the prior -F fixed-string pattern that only matched the bare form.
           PR_BODY=$(gh pr view "$PR_NUMBER" --json body -q .body 2>/dev/null || echo "")
-          if echo "$PR_BODY" | grep -qF '[skip-claude-review]'; then
-            echo "::notice::Claude Code Review enforcement skipped via [skip-claude-review] in PR body."
+          if echo "$PR_BODY" | grep -qE '\[skip-claude-review(\]|:)'; then
+            echo "::notice::Claude Code Review enforcement skipped via [skip-claude-review] marker in PR body."
             echo "## Claude Code Review" >> "$GITHUB_STEP_SUMMARY"
             echo "**Verdict:** SKIPPED (override in PR body)" >> "$GITHUB_STEP_SUMMARY"
             exit 0


### PR DESCRIPTION
## Summary

- Replace `grep -qF '[skip-claude-review]'` at line 305 with extended regex `\[skip-claude-review(\]|:)` so both the bare token **and** the `: reason` form the workflow advertises actually trigger the bypass
- Keep all user-facing docs and error messages on the `: reason` form — it's the better UX (forces an audit trail in the bypass)
- No change to the bare-token behavior

## Why now

Session on 2026-04-17 hit this on [kebab-tax#1162](https://github.com/nightowlstudiollc/kebab-tax/pull/1162): three consecutive infrastructure-failure runs on the same SHA, added `[skip-claude-review: infrastructure flake — …]` to the PR body exactly as the error message instructs, reran → **same failure** because the grep never matched. Only the bare `[skip-claude-review]` form (undocumented) actually fired the bypass. Full report in the user's local AAR.

## Match matrix (verified locally)

| Input | Old (`-qF`) | New (`-qE`) |
|---|---|---|
| `[skip-claude-review]` | ✅ match | ✅ match |
| `[skip-claude-review: reason]` | ❌ no match | ✅ match |
| `[skip-claude-review:]` | ❌ no match | ✅ match |
| `[skip-claude-review` (unclosed) | ❌ | ❌ |
| `[skip-claude-reviewfoo]` | ❌ | ❌ |
| no marker | ❌ | ❌ |

## Test plan

- [x] Regex matrix verified locally (see above)
- [x] Local pre-commit hooks (code-reviewer + adversarial-reviewer) PASS
- [x] Local pre-push hooks (full-diff + codebase reviewer) PASS
- [ ] CI (`Claude Blocking Review`) passes
- [ ] Downstream consumers (`kebab-tax`, etc.) pick up the fix automatically via `@v1` tag once a new tag is cut

## Closes

Closes #38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)