### PR TITLE
chore: restore self-applying caller for dogfooding + required status check

### DIFF
--- a/.github/workflows/self-review.yml
+++ b/.github/workflows/self-review.yml
@@ -1,0 +1,38 @@
+name: Self-Review
+
+# Self-applying caller: runs this repo's reusable Claude Blocking Review
+# workflow on its own PRs. Produces the `claude-review / run-review` status
+# check that branch protection requires on main.
+#
+# Uses a local path (./.github/workflows/claude-blocking-review.yml) rather
+# than a tag, so PR branches dogfood the proposed changes to the reusable
+# workflow against themselves before release.
+#
+# Replaces the .github/workflows/claude-code-review.yml caller that was
+# deleted in commit 52e688b during the v1 rename.
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  id-token: write
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+jobs:
+  claude-review:
+    uses: ./.github/workflows/claude-blocking-review.yml
+    with:
+      pr_number: ${{ github.event.pull_request.number }}
+      extra_instructions: |
+        This repository hosts the reusable `claude-blocking-review.yml`
+        workflow itself. Pay particular attention to:
+        - Shell-injection risk in any step that interpolates PR data
+        - Changes to the verdict file / comment parsing contract that
+          consumer repos depend on
+        - Changes to allowed-tools that could broaden what Claude can run
+        - Grep/regex changes in the escape-hatch path (see #38 history)
+    secrets:
+      claude_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/self-review.yml`, a minimal caller that invokes the reusable `claude-blocking-review.yml` on this repo's own PRs
- Restores the `claude-review / run-review` status check that `main`'s branch protection requires (and that no workflow has produced since commit 52e688b removed the prior caller during the v1 rename)
- Uses a **local path** (`./.github/workflows/claude-blocking-review.yml`), not a tag reference, so PR branches dogfood the *proposed* changes to the reusable workflow against themselves — not the released `@v1` version

## Why

Every PR since `52e688b` (March 27) has been `mergeStateStatus: BLOCKED` and mergeable only via `--admin`:
- #33 (drop haiku) / #34 (raise base to 10) / #35 (raise floor to 25) / #36 (add Read + printf to tools) — all merged admin
- #39 (fix #38 grep) — currently stalled admin-only

Restoring the self-caller means:
1. Changes to the reusable workflow get reviewed by the reusable workflow before ship. #38 would likely have surfaced on a self-review long before it bit users.
2. Future PRs merge through the normal path — no admin-bypass needed, enforcement actually enforces.

## What this PR does NOT change

- The reusable workflow itself is untouched. Only a new caller file.
- No changes to the v1 tag, or to consumer repos.

## Verification

- Local pre-commit + pre-push reviewers: PASS
- Expected to trigger on this PR itself (opened → `Self-Review / claude-review / run-review` check should appear)
- If the check runs green, this PR merges via normal `gh pr merge` (no `--admin`), confirming the fix end-to-end

## Related

- Unblocks PR #39 (grep fix) to merge via normal path once this lands and #39 is rebased
- Enables upcoming PRs (#2 doc-skip + marker + minimize priors, #3 narrow-prompt + lower-floor) to also merge via normal path

## Test plan

- [ ] `Self-Review / claude-review / run-review` appears on this PR and runs
- [ ] Workflow produces a PASS review (diff is a single new YAML file, no BLOCK-worthy content)
- [ ] `gh pr merge <this>` works without `--admin`
- [ ] After merge, rebase #39 onto main → confirm the same check runs green on it too

🤖 Generated with [Claude Code](https://claude.com/claude-code)