### PR TITLE
feat: doc-only fast-skip + SHA marker + prior-comment collapse

### DIFF
--- a/.github/workflows/claude-blocking-review.yml
+++ b/.github/workflows/claude-blocking-review.yml
@@ -374,7 +374,10 @@ jobs:
 
             When uncertain between BLOCK and PASS, default to PASS.
 
-            You MUST complete ALL of the following steps in order:
+            You MUST complete ALL of the following steps in order. The verdict
+            file is written BEFORE the comment post so that if you run out of
+            turns or time during the comment post, CI still has a usable
+            verdict. Do not reorder these steps.
 
             Step 1 — Write your review to /tmp/review.md
 
@@ -384,7 +387,12 @@ jobs:
               # OR (if blocking issues found):
               echo "VERDICT: BLOCK" >> /tmp/review.md
 
-            Step 3 — Post the review as a PR comment. The body MUST begin with a
+            Step 3 — Write the verdict to the verdict file (PRIMARY signal for CI):
+              echo "VERDICT: PASS" > /tmp/review-verdict.txt
+              # OR:
+              echo "VERDICT: BLOCK" > /tmp/review-verdict.txt
+
+            Step 4 — Post the review as a PR comment. The body MUST begin with a
             machine-readable marker line, then a blank line, then the review
             content (which already ends with the VERDICT line from Step 2).
             Run these three commands verbatim — do NOT omit or edit the marker:
@@ -398,13 +406,9 @@ jobs:
             reviews produced by this workflow and associate each one with
             its reviewed commit. Omitting it breaks those consumers.
 
-            Step 4 — Write the verdict to the verdict file:
-              echo "VERDICT: PASS" > /tmp/review-verdict.txt
-              # OR:
-              echo "VERDICT: BLOCK" > /tmp/review-verdict.txt
-
-            The verdict file (Step 4) is the primary signal read by CI. The verdict line
-            appended to the comment (Step 2) is the fallback. Both must match.
+            The verdict file (Step 3) is the primary signal read by CI. The
+            VERDICT line inside the posted comment (Step 2 / Step 4) is the
+            fallback. Both must match.
 
           claude_args: '--max-turns ${{ steps.estimate.outputs.max_turns }} --model ${{ steps.estimate.outputs.model }} --allowed-tools "Read,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(echo *),Bash(cat *),Bash(tee *),Bash(printf *)"'
 
@@ -444,12 +448,17 @@ jobs:
           else
             # Fallback: Claude sometimes includes the verdict in the comment body
             # instead of writing a separate file. Parse the most recent PR comment.
+            # Anchor the grep to line start/end — the prompt instructs Claude to
+            # emit the VERDICT line as the terminal line of the comment. An
+            # unanchored match will hit any "VERDICT: BLOCK" or "VERDICT: PASS"
+            # string in the review prose (e.g., when the review discusses the
+            # verdict contract itself, as PR #47's self-review demonstrated).
             echo "::warning::Verdict file not found — falling back to PR comment parsing."
             COMMENT=$(gh pr view "$PR_NUMBER" --json comments -q '.comments[-1].body' 2>/dev/null || echo "")
-            if echo "$COMMENT" | grep -q "VERDICT: BLOCK"; then
+            if echo "$COMMENT" | grep -qE '^VERDICT: BLOCK$'; then
               VERDICT="VERDICT: BLOCK"
               echo "Verdict source: PR comment (fallback)"
-            elif echo "$COMMENT" | grep -q "VERDICT: PASS"; then
+            elif echo "$COMMENT" | grep -qE '^VERDICT: PASS$'; then
               VERDICT="VERDICT: PASS"
               echo "Verdict source: PR comment (fallback)"
             else

--- a/.github/workflows/claude-blocking-review.yml
+++ b/.github/workflows/claude-blocking-review.yml
@@ -255,17 +255,24 @@ jobs:
           OWNER="${REPO%/*}"
           NAME="${REPO#*/}"
 
+          # `last: 100` (newest comments first) rather than `first:` (oldest)
+          # so markers from recent review iterations are always inside the
+          # window even on noisy PRs. Filter to our marker AND un-minimized
+          # to keep this idempotent across repeated runs.
+          # Use -f (explicit string) for owner/name — -F auto-detects types,
+          # and a repo name that happens to parse as an integer would fail
+          # the String! schema check.
           PRIOR_IDS=$(gh api graphql \
             -f query='query($owner: String!, $name: String!, $number: Int!) {
               repository(owner: $owner, name: $name) {
                 pullRequest(number: $number) {
-                  comments(first: 100) {
+                  comments(last: 100) {
                     nodes { id body isMinimized }
                   }
                 }
               }
             }' \
-            -F owner="$OWNER" -F name="$NAME" -F number="$PR_NUMBER" \
+            -f owner="$OWNER" -f name="$NAME" -F number="$PR_NUMBER" \
             --jq '.data.repository.pullRequest.comments.nodes[] | select(.isMinimized == false) | select(.body | startswith("<!-- claude-blocking-review")) | .id' \
             2>/dev/null || echo "")
 

--- a/.github/workflows/claude-blocking-review.yml
+++ b/.github/workflows/claude-blocking-review.yml
@@ -123,8 +123,54 @@ jobs:
             exit 1
           fi
 
+      - name: Check for doc-only diff
+        id: doc-check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+        run: |
+          # Short-circuit: diffs that only touch docs/meta files don't need a
+          # paid Claude review — the BLOCK criteria (bug, reliability regression,
+          # security, data-loss) don't apply to prose changes. Skips saves real
+          # money per run and eliminates the "3 flakes in a row on a doc-only
+          # PR" pattern observed in the 2026-04-17 AAR (kebab-tax#1162).
+          FILES=$(gh pr diff "$PR_NUMBER" --repo "${GITHUB_REPOSITORY}" --name-only 2>/dev/null || echo "")
+          if [ -z "$FILES" ]; then
+            echo "::warning::Could not determine changed files — proceeding with review."
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          ALL_DOCS=true
+          NON_DOC=""
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            case "$f" in
+              *.md|*.markdown|*.rst|*.txt) ;;
+              LICENSE|LICENSE.*|COPYING|COPYING.*) ;;
+              CHANGELOG|CHANGELOG.*|HISTORY|HISTORY.*|AUTHORS|NOTICE) ;;
+              .gitignore|.gitattributes|.editorconfig|.mailmap) ;;
+              .github/ISSUE_TEMPLATE/*|.github/PULL_REQUEST_TEMPLATE.md) ;;
+              .github/CODEOWNERS|.github/FUNDING.yml|.github/dependabot.yml) ;;
+              docs/*|doc/*) ;;
+              *) ALL_DOCS=false; NON_DOC="$f"; break ;;
+            esac
+          done <<< "$FILES"
+
+          if [ "$ALL_DOCS" = "true" ]; then
+            FILE_COUNT=$(printf '%s\n' "$FILES" | grep -c .)
+            echo "::notice::Doc-only diff (${FILE_COUNT} file(s)) — skipping Claude review."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "## Claude Code Review" >> "$GITHUB_STEP_SUMMARY"
+            echo "**Verdict:** SKIPPED (doc-only diff, ${FILE_COUNT} file(s))" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Non-doc file present ('$NON_DOC') — proceeding with review."
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Estimate review parameters
         id: estimate
+        if: steps.doc-check.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ inputs.pr_number }}
@@ -191,8 +237,56 @@ jobs:
           echo "| Max turns | $MAX_TURNS |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Timeout | ${TIMEOUT}m |" >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Minimize prior review comments
+        if: steps.doc-check.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+        run: |
+          # Collapse prior review comments tagged with the claude-blocking-review
+          # marker. Keeps the PR conversation readable across multiple review
+          # iterations (the AAR observed 4 stale reviews on kebab-tax#1165
+          # polluting both the human-facing timeline and the post-push status
+          # scraper). Non-fatal: any failure here must not block the review.
+          OWNER="${REPO%/*}"
+          NAME="${REPO#*/}"
+
+          PRIOR_IDS=$(gh api graphql \
+            -f query='query($owner: String!, $name: String!, $number: Int!) {
+              repository(owner: $owner, name: $name) {
+                pullRequest(number: $number) {
+                  comments(first: 100) {
+                    nodes { id body isMinimized }
+                  }
+                }
+              }
+            }' \
+            -F owner="$OWNER" -F name="$NAME" -F number="$PR_NUMBER" \
+            --jq '.data.repository.pullRequest.comments.nodes[] | select(.isMinimized == false) | select(.body | startswith("<!-- claude-blocking-review")) | .id' \
+            2>/dev/null || echo "")
+
+          if [ -z "$PRIOR_IDS" ]; then
+            echo "No prior marked review comments to minimize."
+            exit 0
+          fi
+
+          COUNT=0
+          while IFS= read -r id; do
+            [ -z "$id" ] && continue
+            if gh api graphql \
+                 -f query='mutation($id: ID!) { minimizeComment(input: {subjectId: $id, classifier: OUTDATED}) { clientMutationId } }' \
+                 -F id="$id" >/dev/null 2>&1; then
+              COUNT=$((COUNT + 1))
+            else
+              echo "::warning::Failed to minimize prior review comment $id"
+            fi
+          done <<< "$PRIOR_IDS"
+          echo "Minimized $COUNT prior review comment(s) as OUTDATED."
+
       - name: Run Claude Code Review
         id: claude-review
+        if: steps.doc-check.outputs.skip != 'true'
         timeout-minutes: ${{ fromJSON(steps.estimate.outputs.timeout_minutes) }}
         continue-on-error: true  # infrastructure failure must not block merges
         uses: anthropics/claude-code-action@v1
@@ -280,8 +374,19 @@ jobs:
               # OR (if blocking issues found):
               echo "VERDICT: BLOCK" >> /tmp/review.md
 
-            Step 3 — Post the review as a PR comment (the verdict line will be at the end):
-              gh pr comment ${{ inputs.pr_number }} --body "$(cat /tmp/review.md)"
+            Step 3 — Post the review as a PR comment. The body MUST begin with a
+            machine-readable marker line, then a blank line, then the review
+            content (which already ends with the VERDICT line from Step 2).
+            Run these three commands verbatim — do NOT omit or edit the marker:
+
+              printf '<!-- claude-blocking-review sha=%s run=%s -->\n\n' '${{ github.event.pull_request.head.sha }}' '${{ github.run_id }}' > /tmp/review-final.md
+              cat /tmp/review.md >> /tmp/review-final.md
+              gh pr comment ${{ inputs.pr_number }} --body-file /tmp/review-final.md
+
+            The marker lets downstream tooling (status scrapers, the
+            "Minimize prior review comments" step on the next run) identify
+            reviews produced by this workflow and associate each one with
+            its reviewed commit. Omitting it breaks those consumers.
 
             Step 4 — Write the verdict to the verdict file:
               echo "VERDICT: PASS" > /tmp/review-verdict.txt
@@ -299,7 +404,15 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ inputs.pr_number }}
           CLAUDE_OUTCOME: ${{ steps.claude-review.outcome }}
+          DOC_SKIP: ${{ steps.doc-check.outputs.skip }}
         run: |
+          # Short-circuit: doc-only diff already wrote its summary in the
+          # Check for doc-only diff step. Nothing to verify, nothing to block.
+          if [ "$DOC_SKIP" = "true" ]; then
+            echo "Doc-only skip — no verdict required."
+            exit 0
+          fi
+
           # Escape hatch: [skip-claude-review] or [skip-claude-review: reason] in PR body
           # bypasses enforcement. The extended regex matches both the bare token and the
           # documented `: reason` form advertised by our error messages. See issue #38

--- a/.github/workflows/claude-blocking-review.yml
+++ b/.github/workflows/claude-blocking-review.yml
@@ -151,7 +151,10 @@ jobs:
               CHANGELOG|CHANGELOG.*|HISTORY|HISTORY.*|AUTHORS|NOTICE) ;;
               .gitignore|.gitattributes|.editorconfig|.mailmap) ;;
               .github/ISSUE_TEMPLATE/*|.github/PULL_REQUEST_TEMPLATE.md) ;;
-              .github/CODEOWNERS|.github/FUNDING.yml|.github/dependabot.yml) ;;
+              # FUNDING.yml is display-only; CODEOWNERS (approval authority)
+              # and dependabot.yml (dependency sourcing) are intentionally
+              # EXCLUDED — they look meta but have real security impact.
+              .github/FUNDING.yml) ;;
               docs/*|doc/*) ;;
               *) ALL_DOCS=false; NON_DOC="$f"; break ;;
             esac


### PR DESCRIPTION
## Summary

Three coordinated CI-cost reductions targeting failure modes documented in the 2026-04-17 AAR:

- **Doc-only fast-skip** — new pre-step detects diffs that only touch docs/meta files (`*.md`, `LICENSE`, `CHANGELOG`, `.gitignore`, `docs/`, `.github/ISSUE_TEMPLATE/**`, `.github/FUNDING.yml`) and short-circuits the review with `VERDICT: SKIPPED`. PR bodies like kebab-tax#1162 (doc-only, hit 3× flakes this week) would cost $0 instead of 3× timeout-out runs.
- **SHA marker** in every posted review (`<!-- claude-blocking-review sha=<sha> run=<id> -->`). Downstream scrapers can filter to the current HEAD. Fixes the post-push-status.sh phantom-findings issue seen on kebab-tax#1165.
- **Minimize prior reviews** via `minimizeComment` GraphQL mutation (classifier: `OUTDATED`). Keeps the PR conversation tidy across iterations without breaking the rendered review body.

## Intentional scope boundary

`.github/CODEOWNERS` and `.github/dependabot.yml` are explicitly **excluded** from the doc-only allowlist. They look meta but have real security impact (approval authority, dependency sourcing). Changes there should still get a Claude review. See commit `0b45b33` for the rationale.

## What this PR does NOT change

- No change to the BLOCK/PASS contract.
- No change to the required status check name (`claude-review / run-review`).
- No change to the reusable workflow's public inputs or secrets.
- No change to the allowed-tools list at the Claude action invocation — the marker emission uses three sequential `printf` / `cat` / `gh pr comment` commands that already match the existing prefix allowlist.

## Expected cost impact

| Scenario | Before | After |
|---|---|---|
| Doc-only PR | Full review (~5–10 min Claude) | **$0** — skipped |
| PR with N push iterations | N reviews accumulate | N reviews, but prior N-1 collapsed |
| Code PR on first iteration | Full review | Full review (unchanged) |

## Commits

- `7e5d8f3` — feat: add doc-only skip, SHA marker, and prior-comment collapse
- `0b45b33` — fix: exclude CODEOWNERS and dependabot.yml from doc-only allowlist
- `8584ec1` — fix: use `last: 100` and explicit-string GraphQL vars

## Test plan

- [x] Local doc-only detection tested against 7 classification cases
- [x] GraphQL `comments(last: 100)` query verified against PR #41
- [x] `OUTDATED` classifier verified via GraphQL introspection
- [x] Pre-commit + pre-push reviewers all PASS
- [ ] Dogfood: **this very PR** will exercise the Claude review on the new code (real review since the workflow already exists on main)
- [ ] Post-merge, the next PR in this repo (e.g. PR #3) will be the first to exercise the SHA marker, the prior-comment minimize, and a re-review iteration

## Follow-ups (non-blocking, filed during local review)

- #44 — minor `-f` vs `-F` consistency on the minimize mutation's ID variable
- #45 — expand allowlist to include image assets (`*.png`, `*.jpg`, `*.svg`) so README screenshot-only PRs also short-circuit
- #46 — theoretical rename-from-code-to-docs blind spot (would need full-diff parse rather than `--name-only`)

## Closes

- #42 — `comments(first: 100)` vs `last: 100`
- #43 — `-F` type coercion on owner/name strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)