### PR TITLE
polish: resolve doc-only allowlist + marker follow-ups (#44-#46, #48-#50)

### DIFF
--- a/.github/workflows/claude-blocking-review.yml
+++ b/.github/workflows/claude-blocking-review.yml
@@ -427,7 +427,7 @@ jobs:
             content (which already ends with the VERDICT line from Step 2).
             Run these three commands verbatim — do NOT omit or edit the marker:
 
-              printf '<!-- claude-blocking-review sha=%s run=%s -->\n\n' '${{ github.event.pull_request.head.sha }}' '${{ github.run_id }}' > /tmp/review-final.md
+              printf '<!-- claude-blocking-review sha=%s run=%s -->\n\n' '${{ github.event.pull_request.head.sha || github.sha }}' '${{ github.run_id }}' > /tmp/review-final.md
               cat /tmp/review.md >> /tmp/review-final.md
               gh pr comment ${{ inputs.pr_number }} --body-file /tmp/review-final.md
 

--- a/.github/workflows/claude-blocking-review.yml
+++ b/.github/workflows/claude-blocking-review.yml
@@ -293,7 +293,7 @@ jobs:
             [ -z "$id" ] && continue
             if gh api graphql \
                  -f query='mutation($id: ID!) { minimizeComment(input: {subjectId: $id, classifier: OUTDATED}) { clientMutationId } }' \
-                 -F id="$id" >/dev/null 2>&1; then
+                 -f id="$id" >/dev/null 2>&1; then
               COUNT=$((COUNT + 1))
             else
               echo "::warning::Failed to minimize prior review comment $id"

--- a/.github/workflows/claude-blocking-review.yml
+++ b/.github/workflows/claude-blocking-review.yml
@@ -150,15 +150,32 @@ jobs:
           while IFS= read -r f; do
             [ -z "$f" ] && continue
             case "$f" in
-              *.md|*.markdown|*.rst|*.txt) ;;
+              # Explicit NON-DOC exclusions come FIRST — they'd otherwise match
+              # the general *.md / *.yml patterns below. These files look meta
+              # but have real security impact and must not skip review:
+              #   - PULL_REQUEST_TEMPLATE.md: can embed required security
+              #     checklists; removing them should not bypass review.
+              #   - CODEOWNERS: controls approval authority on code paths.
+              #   - dependabot.yml: controls dependency sourcing.
+              .github/PULL_REQUEST_TEMPLATE.md|.github/CODEOWNERS|.github/dependabot.yml)
+                ALL_DOCS=false; NON_DOC="$f"; break ;;
+              # Prose documentation formats. `*.txt` was INTENTIONALLY removed
+              # — it matched dependency manifests like requirements.txt,
+              # constraints.txt, packages.txt that are code-adjacent and
+              # deserve review when they change.
+              *.md|*.markdown|*.rst) ;;
               LICENSE|LICENSE.*|COPYING|COPYING.*) ;;
               CHANGELOG|CHANGELOG.*|HISTORY|HISTORY.*|AUTHORS|NOTICE) ;;
+              # Build-time meta files with negligible runtime behavior impact.
               .gitignore|.gitattributes|.editorconfig|.mailmap) ;;
-              .github/ISSUE_TEMPLATE/*|.github/PULL_REQUEST_TEMPLATE.md) ;;
-              # FUNDING.yml is display-only; CODEOWNERS (approval authority)
-              # and dependabot.yml (dependency sourcing) are intentionally
-              # EXCLUDED — they look meta but have real security impact.
+              # Image assets (usually README screenshots, docs figures).
+              *.png|*.jpg|*.jpeg|*.gif|*.svg|*.webp|*.ico|*.bmp) ;;
+              # User-facing issue forms and the Sponsor button config.
+              .github/ISSUE_TEMPLATE/*) ;;
               .github/FUNDING.yml) ;;
+              # Doc directories at the repo root. Nested doc/ under code paths
+              # (e.g. src/docs/) intentionally NOT covered — if a consumer has
+              # nested docs they still get reviewed, conservative.
               docs/*|doc/*) ;;
               *) ALL_DOCS=false; NON_DOC="$f"; break ;;
             esac

--- a/.github/workflows/claude-blocking-review.yml
+++ b/.github/workflows/claude-blocking-review.yml
@@ -138,7 +138,16 @@ jobs:
           # security, data-loss) don't apply to prose changes. Skips saves real
           # money per run and eliminates the "3 flakes in a row on a doc-only
           # PR" pattern observed in the 2026-04-17 AAR (kebab-tax#1162).
-          FILES=$(gh pr diff "$PR_NUMBER" --repo "${GITHUB_REPOSITORY}" --name-only 2>/dev/null || echo "")
+          #
+          # Use the files API (not `gh pr diff --name-only`) so we get the
+          # pre-rename path for renamed files. A rename like src/foo.py →
+          # docs/foo.md would otherwise only show docs/foo.md (apparent
+          # doc-only) while the diff contains full code deletion. We classify
+          # the UNION of both paths: the PR is doc-only iff every
+          # previous_filename AND every filename matches the allowlist below.
+          FILES=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" --paginate \
+            --jq '.[] | [.previous_filename, .filename] | .[] | select(. != null)' \
+            2>/dev/null | sort -u || echo "")
           if [ -z "$FILES" ]; then
             echo "::warning::Could not determine changed files — proceeding with review."
             echo "skip=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Six follow-up issues filed by local reviewers during the three main session PRs (#39, #47, #52). Bundled into one PR because they share the same files (doc-only `case` block and the marker `printf` line) and four small atomic commits are easier to read than a rewrite.

## Issues resolved

| Commit | Issue | Impact |
|---|---|---|
| `d42d068` | #44 | `-F id` → `-f id` in the `minimizeComment` mutation. Consistency with surrounding `-f` for String-typed vars. |
| `8324219` | #45, #48, #49 | Remove `*.txt` (matched `requirements.txt`-class files), remove `PULL_REQUEST_TEMPLATE.md` (can embed required security checklists), add image extensions (`*.png`, `*.jpg`, `*.jpeg`, `*.gif`, `*.svg`, `*.webp`, `*.ico`, `*.bmp`). |
| `81587ef` | #46 | Switch file enumeration from `gh pr diff --name-only` to the files API, so renamed files contribute both pre-rename and post-rename paths to doc-only classification. A `src/foo.py` → `docs/foo.md` rename can no longer hide code removal behind a doc path. |
| `d311d3f` | #50 | Add `|| github.sha` fallback to the SHA marker so non-pull_request triggers (`workflow_dispatch`, `push`, etc.) still produce a non-empty `sha=` field. |

## Behavioral impact

| Before | After |
|---|---|
| `requirements.txt`, `packages.txt`, `constraints.txt` PRs: doc-only skip | **Reviewed** — dependency changes should not bypass CI |
| README screenshot update (`*.png`): reviewed | **Doc-only skip** — cheap wins |
| `PULL_REQUEST_TEMPLATE.md` edits: doc-only skip | **Reviewed** — template can contain security checklists |
| Renamed code→docs: doc-only skip (silent) | **Reviewed** — union-of-paths classification catches it |
| SHA marker on non-PR triggers | Non-empty fallback to `github.sha` |
| `minimizeComment(ID)` typed via `-F` (auto) | `-f` (explicit string) for consistency with adjacent code |

## What this PR does NOT change

- The BLOCK-only prompt shipped in #52 is unchanged.
- `max_turns` / timeout estimation unchanged.
- Verdict file / fallback grep contract unchanged.
- No public input, secret, or required status check name changes.

## Test plan

- [x] Local pre-commit reviewers PASS on all four commits
- [x] Codebase reviewer PASS (validated rename union-classification, case ordering, SHA expression syntax)
- [x] Classification test matrix: `requirements.txt` → non-doc ✓, `README.md` → doc ✓, `*.png` → doc ✓, `PULL_REQUEST_TEMPLATE.md` → non-doc ✓, `CODEOWNERS` → non-doc ✓
- [ ] Self-review: CI will run under the NEW rename-aware classifier and tightened allowlist
- [ ] Consumer sanity: after merge + v1 retag, watch kebab-tax or similar for regressions

## Closes

Closes #44, #45, #46, #48, #49, #50.

## Next step after this merges

Cut new `v1` tag so consumer repos pick up the full stack (#39 grep, #47 doc-skip + marker + minimize, #52 narrow prompt, plus this one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)