### PR TITLE
fix: allow bot actors to invoke claude-code-action (v2.0.2)

### DIFF
--- a/.github/workflows/claude-assistant.yml
+++ b/.github/workflows/claude-assistant.yml
@@ -47,6 +47,12 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@26ec041249acb0a944c0a47b6c0c13f05dbc5b44 # v1
         with:
+          # claude-code-action rejects non-User actors unless explicitly allowed.
+          # The caller's author_association guard (OWNER/MEMBER/COLLABORATOR) is
+          # the primary authorization — this list only names the bots that are
+          # legitimate secondary triggers (e.g., claude[bot] updating a thread,
+          # github-actions[bot] re-running after a synchronize push).
+          allowed_bots: "claude[bot],github-actions[bot]"
           claude_code_oauth_token: ${{ secrets.claude_oauth_token }}
 
           # Required for Claude to read CI results on PRs

--- a/.github/workflows/claude-blocking-review.yml
+++ b/.github/workflows/claude-blocking-review.yml
@@ -374,6 +374,12 @@ jobs:
         continue-on-error: true  # infrastructure failure must not block merges
         uses: anthropics/claude-code-action@v1
         with:
+          # claude-code-action rejects non-User actors unless explicitly allowed.
+          # Callers use this on pull_request events that fire for bot-opened PRs
+          # (dependabot) and synchronize events triggered by bot pushes (claude,
+          # github-actions). Named list only — see docs/security.md in the action
+          # repo for why `*` is discouraged.
+          allowed_bots: "claude[bot],github-actions[bot],dependabot[bot]"
           claude_code_oauth_token: ${{ secrets.claude_oauth_token }}
           prompt: |
             REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary

Adds `allowed_bots` to both reusable workflows so downstream callers don't fail when `github.actor` resolves to a Bot (dependabot/github-actions/claude).

- `claude-assistant.yml`: `claude[bot],github-actions[bot]`
- `claude-blocking-review.yml`: `claude[bot],github-actions[bot],dependabot[bot]`

## Context

Recent releases of `anthropics/claude-code-action@v1` reject workflow runs where `github.actor` is a Bot unless the bot is explicitly allowed. This bit `nightowlstudiollc/kebab-tax-netlify` PR #173 yesterday (changelog-review workflow) when a `github-actions[bot]` push produced a synchronize event with `github.actor = claude[bot]`. Fix landed there as a one-off (PR #174); this PR applies the same fix to both reusable workflows so every caller inherits it.

### Why different lists per file

`claude-assistant.yml` fires on `@claude` mentions — dependabot doesn't mention @claude, so it's not listed there. `claude-blocking-review.yml` fires on `pull_request` events in callers, which includes dependabot-opened PRs, so `dependabot[bot]` is required.

### Why named list, not `*`

The action's `docs/security.md` warns that `*` on public repos lets external GitHub Apps invoke workflows with prompts they control. Explicit list only.

## Release plan

This is a patch-level change. After merge, please tag `v2.0.2` and fast-forward the `v2` floating tag. Callers pinned to `@v2` pick it up automatically; callers pinned to `@v2.0.1` (e.g., `kebab-tax-netlify/.github/workflows/claude-blocking-review.yml`) will need a separate bump PR.

## Test plan

- [x] YAML parses for both files
- [x] Local code-reviewer + adversarial-reviewer: PASS
- [ ] After merge + v2.0.2 tag: bump `kebab-tax-netlify` from `@v2.0.1` → `@v2.0.2` and confirm a dependabot PR (or synchronize push) gets a clean `claude-review` status
- [ ] Review `claude-blocking-review`'s own PR-run on this PR — since commit `a2566ef` short-circuits on `.github/workflows/*.yml` modifications, it should skip rather than hit the very bug being fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)