### PR TITLE
chore(security): SHA-pin third-party actions in claude-blocking-review.yml

### DIFF
--- a/.github/workflows/claude-blocking-review.yml
+++ b/.github/workflows/claude-blocking-review.yml
@@ -87,7 +87,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 1
 
@@ -339,7 +339,7 @@ jobs:
         if: steps.doc-check.outputs.skip != 'true'
         timeout-minutes: ${{ fromJSON(steps.estimate.outputs.timeout_minutes) }}
         continue-on-error: true  # infrastructure failure must not block merges
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@26ec041249acb0a944c0a47b6c0c13f05dbc5b44  # v1
         with:
           # claude-code-action rejects non-User actors unless explicitly allowed.
           # Callers use this on pull_request events that fire for bot-opened PRs


### PR DESCRIPTION
## Summary

Brings `claude-blocking-review.yml` in line with `claude-assistant.yml`, which has been SHA-pinning these same two actions all along. Tag-pinning was flagged in the 2026-04-29 GitHub Actions audit (against the patterns in [GitHub Actions Is The Weakest Link](https://nesbitt.io/2026/04/28/github-actions-is-the-weakest-link.html), pattern #2 — mutable action references).

## Changes

Pinned to the same SHAs already used in `claude-assistant.yml`:

- `actions/checkout@v4` → `34e114876b0b11c390a56381ad16ebd13914f8d5`
- `anthropics/claude-code-action@v1` → `26ec041249acb0a944c0a47b6c0c13f05dbc5b44`

This is a reusable workflow consumed via `@v3` by all 26 sister repos. The pin doesn't shift the semver contract for callers — only what the runner resolves the third-party `uses:` lines to inside the v3 release. No `@v3.x` bump needed.

Tag comments preserved so Dependabot keeps the SHAs current.

## Test plan

- [ ] `self-review.yml` (the dogfooding caller) passes — the proposed reusable runs against this very PR
- [ ] No behavioral change visible to consumers of `@v3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)