### PR TITLE
feat: bulk-install-claude-review.sh for smartwatermelon fleet

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,3 +201,44 @@ Requires: `gh` CLI (authenticated), `jq`, `bash` 4.0+.
 
 Add repos to `.claude-review-ignore` (one `owner/repo` per line) to skip them
 in audits. Useful for repos that should never have the review installed.
+
+---
+
+## Bulk-install script (`smartwatermelon` only)
+
+`bulk-install-claude-review.sh` installs (or refreshes) the
+`claude-blocking-review` caller workflow across all non-archived repos under
+`smartwatermelon`. Workaround for the fact that GitHub's workflow-templates
+picker is **organization-only** — `smartwatermelon` is a user account, so
+the templates in `smartwatermelon/.github/workflow-templates/` never appear
+in the "New workflow" picker for `smartwatermelon/*` repos.
+
+```bash
+./bulk-install-claude-review.sh                          # dry-run (default)
+./bulk-install-claude-review.sh --apply                  # open PRs
+./bulk-install-claude-review.sh --only smartwatermelon/foo --apply
+```
+
+The script classifies each repo:
+
+| Class | Action |
+|-------|--------|
+| `CURRENT` | Already on the target version. No-op. |
+| `STALE` | Different pin or floating tag. Opens a PR bumping the pin. |
+| `MISSING` | No caller workflow at all. Opens a PR adding the canonical stub. |
+| `CUSTOMIZED` | Has caller-side modifications (`paths-ignore`, `extra_instructions`, etc.). Skipped — flag for human review. |
+| `LOCAL` | Uses a local-path reference (`./...`). Not bumpable; e.g. the `github-workflows` repo's own self-review. |
+
+Target version is derived dynamically from the `@v…` pin in
+`smartwatermelon/.github/workflow-templates/claude-blocking-review.yml`,
+so a PR bumping that template is the single trigger to roll a new version
+across the fleet.
+
+PRs include `[skip-claude-review: bulk-install]` in the body so the
+blocking-review workflow doesn't gate its own install/bump PR.
+
+For `nightowlstudiollc`, this script is intentionally not used — that org gets
+the workflow-templates picker for new repos, and (planned) Repository Rulesets
+for org-wide enforcement.
+
+Plan: `docs/plans/2026-04-30-bulk-install-smartwatermelon-fleet.md`.

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ The script classifies each repo:
 | `CURRENT` | Already on the target version. No-op. |
 | `STALE` | Different pin or floating tag. Opens a PR bumping the pin. |
 | `MISSING` | No caller workflow at all. Opens a PR adding the canonical stub. |
-| `CUSTOMIZED` | Has caller-side modifications (`paths-ignore`, `extra_instructions`, etc.). Skipped — flag for human review. |
+| `CUSTOMIZED` | Has caller-side modifications (`paths-ignore`, `extra_instructions`, custom `model`/`timeout_minutes`, etc.). Skipped regardless of pin — flag for human review. |
 | `LOCAL` | Uses a local-path reference (`./...`). Not bumpable; e.g. the `github-workflows` repo's own self-review. |
 
 Target version is derived dynamically from the `@v…` pin in

--- a/bulk-install-claude-review.sh
+++ b/bulk-install-claude-review.sh
@@ -206,9 +206,13 @@ open_install_pr() {
     return 1
   fi
 
-  # PUT file contents on the new branch
+  # PUT file contents on the new branch.
+  # `printf "%s\n"` re-adds the trailing newline that command substitution
+  # (the $() that captured CANONICAL_CONTENT / current_content earlier)
+  # strips from text files. Without this, every install/bump PR would
+  # produce a file failing yamllint's "no newline at end of file" rule.
   local b64_content
-  b64_content="$(printf "%s" "${file_content}" | base64 | tr -d '\n')"
+  b64_content="$(printf "%s\n" "${file_content}" | base64 | tr -d '\n')"
   local put_payload
   if [[ -n "${existing_sha}" ]]; then
     put_payload="$(jq -n \
@@ -292,7 +296,7 @@ process_repo() {
       local body
       body="$(pr_body_template "Install missing caller workflow")"
       open_install_pr "${full}" \
-        "claude/install-blocking-review" \
+        "claude/install-blocking-review-${TARGET_VERSION}" \
         "ci: install claude-blocking-review caller (${TARGET_VERSION})" \
         "ci: install claude-blocking-review caller (${TARGET_VERSION})" \
         "${body}" \

--- a/bulk-install-claude-review.sh
+++ b/bulk-install-claude-review.sh
@@ -105,7 +105,12 @@ if [[ -z "${CANONICAL_CONTENT}" ]]; then
   exit 3
 fi
 
-TARGET_VERSION="$(echo "${CANONICAL_CONTENT}" \
+# strip_comments before grep so a commented-out @version (e.g. an
+# example block) can't be picked up as the canonical pin. Same defense
+# extract_pin uses for consumer files.
+strip_comments() { echo "${1}" | grep -v '^[[:space:]]*#'; }
+
+TARGET_VERSION="$(strip_comments "${CANONICAL_CONTENT}" \
   | grep -m1 -oE 'claude-blocking-review\.yml@[A-Za-z0-9._/-]+' \
   | sed 's/^.*@//')"
 
@@ -125,7 +130,7 @@ declare -a REPOS_ERROR=()
 declare -a PR_URLS=()
 
 # ── helpers ─────────────────────────────────────────────────────────────────────
-strip_comments() { echo "${1}" | grep -v '^[[:space:]]*#'; }
+# strip_comments is defined earlier (before TARGET_VERSION extraction)
 
 uses_blocking_review() {
   strip_comments "${1}" | grep -q "claude-blocking-review\.yml"

--- a/bulk-install-claude-review.sh
+++ b/bulk-install-claude-review.sh
@@ -146,7 +146,7 @@ uses_local_path() {
 
 # Detect customization: caller has any of these non-trivial extras
 has_customization() {
-  echo "${1}" | grep -qE '^\s*(paths-ignore|paths|extra_instructions|model|timeout_minutes|env):' \
+  echo "${1}" | grep -qE '^[[:space:]]*(paths-ignore|paths|extra_instructions|model|timeout_minutes|env):' \
     || echo "${1}" | grep -q '\[skip-claude-review:'
 }
 

--- a/bulk-install-claude-review.sh
+++ b/bulk-install-claude-review.sh
@@ -1,0 +1,419 @@
+#!/usr/bin/env bash
+# bulk-install-claude-review.sh
+#
+# Bulk-installs (or refreshes) the claude-blocking-review caller workflow
+# across all eligible repos under the smartwatermelon user account.
+#
+# Workaround for the fact that GitHub's workflow-templates picker is
+# org-only — smartwatermelon is a user account, so workflow-templates
+# in smartwatermelon/.github never appear in the picker UI for
+# smartwatermelon/* repos. This script closes that gap by opening
+# install/refresh PRs.
+#
+# Behavior:
+#   - DRY-RUN BY DEFAULT. Use --apply to actually open PRs.
+#   - Classifies each repo as MISSING / STALE / CURRENT / CUSTOMIZED.
+#   - Opens at most one PR per repo per invocation.
+#   - Idempotent: re-running with no changes produces no PRs.
+#
+# Source of truth for the canonical caller stub:
+#   smartwatermelon/.github/workflow-templates/claude-blocking-review.yml
+# at HEAD. The script extracts the @vX.Y.Z pin from that file and uses
+# it as the target version.
+#
+# Requirements: gh CLI (authenticated, repo + workflow scopes), jq,
+# base64, bash 4.0+, GNU grep/sed via PATH (works fine on macOS with
+# stock /usr/bin/grep).
+#
+# Usage:
+#   ./bulk-install-claude-review.sh [--dry-run|--apply] [--only owner/repo] [--verbose]
+
+set -uo pipefail
+
+if [[ "${BASH_VERSINFO[0]}" -lt 4 ]]; then
+  printf "Error: bash 4.0+ required (found %s). Run as: ./%s\n" \
+    "${BASH_VERSION}" "${0##*/}" >&2
+  exit 1
+fi
+
+# ── config ─────────────────────────────────────────────────────────────────────
+TARGET_OWNER="smartwatermelon"
+CANONICAL_REPO="smartwatermelon/.github"
+CANONICAL_PATH="workflow-templates/claude-blocking-review.yml"
+INSTALL_PATH=".github/workflows/claude-code-review.yml"
+IGNORE_FILE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/.claude-review-ignore"
+PLAN_LINK="https://github.com/smartwatermelon/github-workflows/blob/main/docs/plans/2026-04-30-bulk-install-smartwatermelon-fleet.md"
+
+# ── flag parsing ────────────────────────────────────────────────────────────────
+APPLY=false
+ONLY=""
+VERBOSE=false
+
+while [[ "$#" -gt 0 ]]; do
+  case "${1}" in
+    --dry-run) APPLY=false ;;
+    --apply) APPLY=true ;;
+    --only)
+      shift
+      ONLY="${1:-}"
+      ;;
+    --verbose) VERBOSE=true ;;
+    -h | --help)
+      sed -n '2,/^$/p' "${BASH_SOURCE[0]}" | sed 's/^# \?//'
+      exit 0
+      ;;
+    *)
+      printf "Error: unknown argument '%s'\n" "${1}" >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+# ── formatting ──────────────────────────────────────────────────────────────────
+ok() { printf "  ✅ %s\n" "${*}"; }
+fail() { printf "  ❌ %s\n" "${*}"; }
+warn() { printf "  ⚠️  %s\n" "${*}"; }
+info() { ${VERBOSE} && printf "  ℹ  %s\n" "${*}" || true; }
+note() { printf "  → %s\n" "${*}"; }
+
+# ── load ignore list ────────────────────────────────────────────────────────────
+declare -A IGNORED_REPOS=()
+if [[ -f "${IGNORE_FILE}" ]]; then
+  while IFS= read -r line; do
+    line="${line%%#*}"
+    line="${line// /}"
+    [[ -z "${line}" ]] && continue
+    IGNORED_REPOS["${line}"]=1
+  done <"${IGNORE_FILE}"
+fi
+
+# ── fetch canonical stub & extract target version ─────────────────────────────
+fetch_file() {
+  local full="${1}" path="${2}"
+  gh api "repos/${full}/contents/${path}" --jq '.content' 2>/dev/null \
+    | tr -d '\n' | base64 -d 2>/dev/null
+}
+
+CANONICAL_CONTENT="$(fetch_file "${CANONICAL_REPO}" "${CANONICAL_PATH}")"
+if [[ -z "${CANONICAL_CONTENT}" ]]; then
+  fail "Could not fetch canonical stub from ${CANONICAL_REPO}/${CANONICAL_PATH}"
+  exit 3
+fi
+
+TARGET_VERSION="$(echo "${CANONICAL_CONTENT}" \
+  | grep -m1 -oE 'claude-blocking-review\.yml@[^[:space:]]+' \
+  | sed 's/^.*@//')"
+
+if [[ -z "${TARGET_VERSION}" ]]; then
+  fail "Canonical stub does not contain a @version pin — aborting"
+  exit 3
+fi
+
+# ── accumulators ─────────────────────────────────────────────────────────────────
+declare -a REPOS_MISSING=()
+declare -a REPOS_STALE=()
+declare -a REPOS_CURRENT=()
+declare -a REPOS_CUSTOMIZED=()
+declare -a REPOS_LOCAL=()
+declare -a REPOS_SKIPPED=()
+declare -a REPOS_ERROR=()
+declare -a PR_URLS=()
+
+# ── helpers ─────────────────────────────────────────────────────────────────────
+strip_comments() { echo "${1}" | grep -v '^[[:space:]]*#'; }
+
+uses_blocking_review() {
+  strip_comments "${1}" | grep -q "claude-blocking-review\.yml"
+}
+
+# Extract the @version pin from a workflow file (first match in non-comment lines)
+extract_pin() {
+  strip_comments "${1}" | grep -m1 -oE 'claude-blocking-review\.yml@[^[:space:]]+' \
+    | sed 's/^.*@//'
+}
+
+# Detect local-path caller (uses ./<path> rather than a tagged reference)
+uses_local_path() {
+  strip_comments "${1}" | grep -qE 'uses:[[:space:]]*\./'
+}
+
+# Detect customization: caller has any of these non-trivial extras
+has_customization() {
+  echo "${1}" | grep -qE '^\s*(paths-ignore|paths|extra_instructions|model|timeout_minutes|env):' \
+    || echo "${1}" | grep -q '\[skip-claude-review:'
+}
+
+# Find the workflow file referencing the blocking review (returns "path|sha")
+find_caller_file() {
+  local full="${1}"
+  local files
+  files="$(gh api "repos/${full}/contents/.github/workflows" \
+    --jq '.[] | "\(.name)|\(.sha)"' 2>/dev/null || echo "")"
+  while IFS='|' read -r name sha; do
+    [[ -z "${name}" ]] && continue
+    local content
+    content="$(fetch_file "${full}" ".github/workflows/${name}")"
+    if uses_blocking_review "${content}"; then
+      printf "%s|%s\n" ".github/workflows/${name}" "${sha}"
+      return 0
+    fi
+  done <<<"${files}"
+  return 1
+}
+
+# ── PR-creation primitives ──────────────────────────────────────────────────────
+# Open a PR adding/updating the install file. Args: full_repo, branch_name,
+# commit_title, pr_title, pr_body, file_path, file_content, [existing_sha]
+open_install_pr() {
+  local full="${1}" branch="${2}" commit_title="${3}" pr_title="${4}" pr_body="${5}"
+  local file_path="${6}" file_content="${7}" existing_sha="${8:-}"
+
+  if ! ${APPLY}; then
+    note "[dry-run] Would open PR: ${full} | branch=${branch} | file=${file_path}"
+    return 0
+  fi
+
+  # Determine base branch
+  local default_branch
+  default_branch="$(gh api "repos/${full}" --jq '.default_branch' 2>/dev/null || echo "main")"
+
+  # Get base SHA
+  local base_sha
+  base_sha="$(gh api "repos/${full}/git/refs/heads/${default_branch}" \
+    --jq '.object.sha' 2>/dev/null)"
+  if [[ -z "${base_sha}" ]]; then
+    fail "Could not resolve base SHA for ${full}@${default_branch}"
+    return 1
+  fi
+
+  # Create branch
+  if ! gh api -X POST "repos/${full}/git/refs" \
+    -f ref="refs/heads/${branch}" -f sha="${base_sha}" >/dev/null 2>&1; then
+    # Already exists? Fail loudly so we don't accidentally re-push.
+    fail "Branch ${branch} already exists on ${full} — aborting this repo"
+    return 1
+  fi
+
+  # PUT file contents on the new branch
+  local b64_content
+  b64_content="$(printf "%s" "${file_content}" | base64 | tr -d '\n')"
+  local put_payload
+  if [[ -n "${existing_sha}" ]]; then
+    put_payload="$(jq -n \
+      --arg msg "${commit_title}" \
+      --arg branch "${branch}" \
+      --arg content "${b64_content}" \
+      --arg sha "${existing_sha}" \
+      '{message:$msg, branch:$branch, content:$content, sha:$sha}')"
+  else
+    put_payload="$(jq -n \
+      --arg msg "${commit_title}" \
+      --arg branch "${branch}" \
+      --arg content "${b64_content}" \
+      '{message:$msg, branch:$branch, content:$content}')"
+  fi
+
+  if ! gh api -X PUT "repos/${full}/contents/${file_path}" \
+    --input - <<<"${put_payload}" >/dev/null 2>&1; then
+    fail "Failed to PUT ${file_path} on ${full}@${branch}"
+    return 1
+  fi
+
+  # Open PR
+  local pr_url
+  pr_url="$(gh pr create --repo "${full}" \
+    --base "${default_branch}" \
+    --head "${branch}" \
+    --title "${pr_title}" \
+    --body "${pr_body}" 2>/dev/null)"
+  if [[ -z "${pr_url}" ]]; then
+    fail "Failed to open PR on ${full} (${branch} created and file pushed; PR creation failed)"
+    return 1
+  fi
+  ok "Opened ${pr_url}"
+  PR_URLS+=("${pr_url}")
+}
+
+pr_body_template() {
+  local action="${1}"
+  cat <<EOF
+[skip-claude-review: bulk-install]
+
+This PR was generated by \`bulk-install-claude-review.sh\` from
+[smartwatermelon/github-workflows](https://github.com/smartwatermelon/github-workflows).
+
+**Action:** ${action}
+**Target version:** \`${TARGET_VERSION}\`
+**Plan:** ${PLAN_LINK}
+
+The escape-hatch tag in this PR body causes the blocking-review workflow
+to skip itself when it runs against this PR — necessary because the
+workflow being installed/updated is what would otherwise gate the merge.
+
+After merge, future PRs in this repo will be reviewed by the workflow
+at the new version. Dependabot (if installed) will detect future bumps
+via the github-actions ecosystem.
+EOF
+}
+
+# ── per-repo processing ─────────────────────────────────────────────────────────
+process_repo() {
+  local repo="${1}"
+  local full="${TARGET_OWNER}/${repo}"
+
+  printf "\n── %s\n" "${full}"
+
+  if [[ -n "${IGNORED_REPOS["${full}"]:-}" ]]; then
+    note "Skipped (in .claude-review-ignore)"
+    REPOS_SKIPPED+=("${full}")
+    return
+  fi
+
+  # Find existing caller file (if any)
+  local found
+  found="$(find_caller_file "${full}" || true)"
+
+  if [[ -z "${found}" ]]; then
+    fail "MISSING — no workflow references claude-blocking-review.yml"
+    REPOS_MISSING+=("${full}")
+    if ${APPLY}; then
+      local body
+      body="$(pr_body_template "Install missing caller workflow")"
+      open_install_pr "${full}" \
+        "claude/install-blocking-review" \
+        "ci: install claude-blocking-review caller (${TARGET_VERSION})" \
+        "ci: install claude-blocking-review caller (${TARGET_VERSION})" \
+        "${body}" \
+        "${INSTALL_PATH}" \
+        "${CANONICAL_CONTENT}"
+    else
+      note "[dry-run] Would open install PR (file: ${INSTALL_PATH}, version: ${TARGET_VERSION})"
+    fi
+    return
+  fi
+
+  local file_path file_sha
+  IFS='|' read -r file_path file_sha <<<"${found}"
+
+  local current_content
+  current_content="$(fetch_file "${full}" "${file_path}")"
+
+  if uses_local_path "${current_content}"; then
+    ok "LOCAL — caller uses a local path reference (no remote pin to bump)"
+    REPOS_LOCAL+=("${full}")
+    return
+  fi
+
+  local current_pin
+  current_pin="$(extract_pin "${current_content}")"
+
+  if [[ -z "${current_pin}" ]]; then
+    warn "ERROR — caller references claude-blocking-review.yml but no @version pin found"
+    REPOS_ERROR+=("${full}")
+    return
+  fi
+
+  if [[ "${current_pin}" == "${TARGET_VERSION}" ]]; then
+    if has_customization "${current_content}"; then
+      warn "CUSTOMIZED — on target (${current_pin}) but has caller-side customizations; skipping"
+      REPOS_CUSTOMIZED+=("${full}")
+    else
+      ok "CURRENT — already on ${TARGET_VERSION}"
+      REPOS_CURRENT+=("${full}")
+    fi
+    return
+  fi
+
+  fail "STALE — pinned at ${current_pin}, target is ${TARGET_VERSION}"
+  REPOS_STALE+=("${full}")
+
+  # Build new content: replace the pin in the existing file (preserves any
+  # caller-side customizations that we'd otherwise overwrite). This is
+  # different from MISSING, which uses the canonical stub verbatim.
+  local new_content
+  new_content="$(echo "${current_content}" \
+    | sed -E "s|claude-blocking-review\.yml@[^[:space:]]+|claude-blocking-review.yml@${TARGET_VERSION}|")"
+
+  if ${APPLY}; then
+    local body
+    body="$(pr_body_template "Bump pin from \`${current_pin}\` → \`${TARGET_VERSION}\`")"
+    open_install_pr "${full}" \
+      "claude/bump-blocking-review-${TARGET_VERSION}" \
+      "ci: bump claude-blocking-review to ${TARGET_VERSION}" \
+      "ci: bump claude-blocking-review to ${TARGET_VERSION}" \
+      "${body}" \
+      "${file_path}" \
+      "${new_content}" \
+      "${file_sha}"
+  else
+    note "[dry-run] Would open bump PR (file: ${file_path}, ${current_pin} → ${TARGET_VERSION})"
+  fi
+}
+
+# ── main ────────────────────────────────────────────────────────────────────────
+mode="DRY-RUN"
+${APPLY} && mode="APPLY"
+
+printf "\n══════════════════════════════════════════════════════════\n"
+printf "  Bulk-install Claude Review (%s mode)\n" "${mode}"
+printf "  Owner: %s\n" "${TARGET_OWNER}"
+printf "  Canonical source: %s/%s\n" "${CANONICAL_REPO}" "${CANONICAL_PATH}"
+printf "  Target version: %s\n" "${TARGET_VERSION}"
+printf "══════════════════════════════════════════════════════════\n"
+
+if [[ -n "${ONLY}" ]]; then
+  if [[ "${ONLY}" != ${TARGET_OWNER}/* ]]; then
+    fail "--only must be in form ${TARGET_OWNER}/<repo>; got '${ONLY}'"
+    exit 2
+  fi
+  process_repo "${ONLY#"${TARGET_OWNER}/"}"
+else
+  repos="$(gh repo list "${TARGET_OWNER}" --no-archived --json name --limit 300 \
+    --jq '.[].name' 2>/dev/null || echo "")"
+  if [[ -z "${repos}" ]]; then
+    fail "Could not list repos for ${TARGET_OWNER}"
+    exit 3
+  fi
+  while IFS= read -r repo; do
+    [[ -z "${repo}" ]] && continue
+    process_repo "${repo}"
+  done <<<"${repos}"
+fi
+
+# ── final summary ───────────────────────────────────────────────────────────────
+printf "\n\n══════════════════════════════════════════════════════════\n"
+printf "  SUMMARY (%s)\n" "${mode}"
+printf "══════════════════════════════════════════════════════════\n"
+printf "  CURRENT     (no action): %d\n" "${#REPOS_CURRENT[@]}"
+printf "  CUSTOMIZED  (skipped):   %d\n" "${#REPOS_CUSTOMIZED[@]}"
+printf "  LOCAL       (no pin):    %d\n" "${#REPOS_LOCAL[@]}"
+printf "  SKIPPED     (ignore):    %d\n" "${#REPOS_SKIPPED[@]}"
+printf "  STALE       (will bump): %d\n" "${#REPOS_STALE[@]}"
+printf "  MISSING     (will add):  %d\n" "${#REPOS_MISSING[@]}"
+printf "  ERROR:                   %d\n" "${#REPOS_ERROR[@]}"
+
+list_section() {
+  local title="${1}"
+  shift
+  local -a items=("${@}")
+  [[ "${#items[@]}" -eq 0 ]] && return
+  printf "\n  %s:\n" "${title}"
+  for r in "${items[@]}"; do printf "    - %s\n" "${r}"; done
+}
+
+list_section "MISSING" "${REPOS_MISSING[@]+"${REPOS_MISSING[@]}"}"
+list_section "STALE" "${REPOS_STALE[@]+"${REPOS_STALE[@]}"}"
+list_section "CUSTOMIZED" "${REPOS_CUSTOMIZED[@]+"${REPOS_CUSTOMIZED[@]}"}"
+list_section "ERROR" "${REPOS_ERROR[@]+"${REPOS_ERROR[@]}"}"
+
+if [[ "${#PR_URLS[@]}" -gt 0 ]]; then
+  printf "\n  PRs opened:\n"
+  for u in "${PR_URLS[@]}"; do printf "    %s\n" "${u}"; done
+fi
+
+if ! ${APPLY} && [[ "${#REPOS_MISSING[@]}" -gt 0 || "${#REPOS_STALE[@]}" -gt 0 ]]; then
+  printf "\n  Re-run with --apply to actually open PRs.\n"
+fi
+
+printf "\n══════════════════════════════════════════════════════════\n\n"

--- a/bulk-install-claude-review.sh
+++ b/bulk-install-claude-review.sh
@@ -56,6 +56,10 @@ while [[ "$#" -gt 0 ]]; do
     --only)
       shift
       ONLY="${1:-}"
+      if [[ -z "${ONLY}" || "${ONLY}" == --* ]]; then
+        printf "Error: --only requires a non-empty owner/repo argument\n" >&2
+        exit 2
+      fi
       ;;
     --verbose) VERBOSE=true ;;
     -h | --help)
@@ -102,7 +106,7 @@ if [[ -z "${CANONICAL_CONTENT}" ]]; then
 fi
 
 TARGET_VERSION="$(echo "${CANONICAL_CONTENT}" \
-  | grep -m1 -oE 'claude-blocking-review\.yml@[^[:space:]]+' \
+  | grep -m1 -oE 'claude-blocking-review\.yml@[A-Za-z0-9._/-]+' \
   | sed 's/^.*@//')"
 
 if [[ -z "${TARGET_VERSION}" ]]; then
@@ -127,9 +131,11 @@ uses_blocking_review() {
   strip_comments "${1}" | grep -q "claude-blocking-review\.yml"
 }
 
-# Extract the @version pin from a workflow file (first match in non-comment lines)
+# Extract the @version pin from a workflow file (first match in non-comment lines).
+# Restricted to characters valid in git refs/SHAs to avoid capturing trailing
+# punctuation (commas, quotes) from YAML.
 extract_pin() {
-  strip_comments "${1}" | grep -m1 -oE 'claude-blocking-review\.yml@[^[:space:]]+' \
+  strip_comments "${1}" | grep -m1 -oE 'claude-blocking-review\.yml@[A-Za-z0-9._/-]+' \
     | sed 's/^.*@//'
 }
 
@@ -299,9 +305,26 @@ process_repo() {
   local current_content
   current_content="$(fetch_file "${full}" "${file_path}")"
 
+  if [[ -z "${current_content}" ]]; then
+    warn "ERROR — could not fetch ${file_path} (transient gh API failure?)"
+    REPOS_ERROR+=("${full}")
+    return
+  fi
+
   if uses_local_path "${current_content}"; then
     ok "LOCAL — caller uses a local path reference (no remote pin to bump)"
     REPOS_LOCAL+=("${full}")
+    return
+  fi
+
+  # Check customization BEFORE pin comparison: any caller-side customization
+  # is reason to skip automated bumping, even if the pin is stale. The sed
+  # that bumps a stale pin is safe by itself, but a customized caller may
+  # have intent we shouldn't second-guess (paths-ignore semantics, custom
+  # extra_instructions, etc.) — flag for human review instead.
+  if has_customization "${current_content}"; then
+    warn "CUSTOMIZED — caller has paths-ignore/extra_instructions/etc; skipping (human review)"
+    REPOS_CUSTOMIZED+=("${full}")
     return
   fi
 
@@ -315,13 +338,8 @@ process_repo() {
   fi
 
   if [[ "${current_pin}" == "${TARGET_VERSION}" ]]; then
-    if has_customization "${current_content}"; then
-      warn "CUSTOMIZED — on target (${current_pin}) but has caller-side customizations; skipping"
-      REPOS_CUSTOMIZED+=("${full}")
-    else
-      ok "CURRENT — already on ${TARGET_VERSION}"
-      REPOS_CURRENT+=("${full}")
-    fi
+    ok "CURRENT — already on ${TARGET_VERSION}"
+    REPOS_CURRENT+=("${full}")
     return
   fi
 
@@ -417,3 +435,10 @@ if ! ${APPLY} && [[ "${#REPOS_MISSING[@]}" -gt 0 || "${#REPOS_STALE[@]}" -gt 0 ]
 fi
 
 printf "\n══════════════════════════════════════════════════════════\n\n"
+
+# Surface ERROR class to callers (CI, cron, automation). Non-zero exit
+# ensures fetch failures don't go silent. CUSTOMIZED is intentionally
+# not an error — it's a human-review signal.
+if [[ "${#REPOS_ERROR[@]}" -gt 0 ]]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Adds `bulk-install-claude-review.sh` at the repo root. Closes the workflow-templates gap for `smartwatermelon`, which is a user account — GitHub's `workflow-templates/` picker is org-only, so the templates in `smartwatermelon/.github/workflow-templates/` never appear in the picker UI for `smartwatermelon/*` repos. This script opens install/refresh PRs to roll the canonical caller stub across the fleet instead.

**Behavior:**
- Dry-run by default; `--apply` opens PRs.
- Classifies each repo: `CURRENT` / `STALE` / `MISSING` / `CUSTOMIZED` / `LOCAL` / `ERROR`.
- Idempotent — re-running on a clean fleet produces no PRs.
- Target version derived from the `@v…` pin in `smartwatermelon/.github/workflow-templates/claude-blocking-review.yml`. Bumping that template is the single fleet-wide trigger.
- PR bodies carry `[skip-claude-review: bulk-install]` so the blocking-review workflow doesn't gate its own install/bump PR.

**Live dry-run results** against the smartwatermelon fleet right now:

| Class | Count | Repos |
|---|---|---|
| CURRENT | 14 | (already at @v3.0.0) |
| STALE | 4 | ralph-burndown, mac-server-setup, scripts, projectinsomnia |
| MISSING | 1 | smartwatermelon/.github |
| LOCAL | 1 | github-workflows itself (self-review) |

**Two commits:**
1. Initial implementation
2. Five fixes from code-reviewer's first pass: validate per-repo fetch, reorder customization check before pin check, tighten extract_pin regex against trailing punctuation, validate `--only` argument, exit non-zero on ERROR class.

Plan: `docs/plans/2026-04-30-bulk-install-smartwatermelon-fleet.md`.

## Test plan

- [x] `shellcheck -S info` clean
- [x] Dry-run against full fleet correctly classifies all 20 repos
- [x] `--only --apply` (missing arg) errors out instead of silently iterating fleet
- [x] code-reviewer + adversarial-reviewer PASS on second commit
- [ ] CI green
- [ ] Manual `--apply` rollout still pending — bellwether 1-2 repos before fleet-wide

🤖 Generated with [Claude Code](https://claude.com/claude-code)