### PR TITLE
docs: correct OAuth token provisioning model in nightowl plans

### DIFF
--- a/docs/plans/2026-04-30-create-nightowlstudiollc-github-defaults.md
+++ b/docs/plans/2026-04-30-create-nightowlstudiollc-github-defaults.md
@@ -20,8 +20,8 @@ This addresses the "new repos automatically inherit" half of the original questi
 ## Preconditions
 
 - Org admin access to `nightowlstudiollc`.
-- `CLAUDE_CODE_OAUTH_TOKEN` already provisioned at the org level, OR plan to add it during this rollout. Check before starting: `gh secret list --org nightowlstudiollc`.
-- The `smartwatermelon/.github` template fix (PR currently open at `smartwatermelon/.github#7`) merged. The mirror should land at `@v3.0.0`, not stale `@v2.0.1`.
+- `CLAUDE_CODE_OAUTH_TOKEN` is provisioned **per-repo** by Claude Code CLI's `/install-github-app`. There is no org-level installation scope. Andrew's working baseline is that every repo he owns already has the App installed; a missing secret on a specific repo is a remediation gap to flag, not an org-level config item. `claude-review-audit.sh` reports which repos lack the secret.
+- The `smartwatermelon/.github` template fix (PR `smartwatermelon/.github#7`) merged. The mirror should land at `@v3.0.0`, not stale `@v2.0.1`.
 
 ## Phases
 
@@ -76,13 +76,14 @@ Copy from `smartwatermelon/.github`:
 
 Skip `.github/FUNDING.yml` unless decided otherwise in Phase 0.
 
-### Phase 3 — Provision org-level secret
+### Phase 3 — Verify the GitHub App is installed on target repos
 
-```bash
-gh secret set CLAUDE_CODE_OAUTH_TOKEN --org nightowlstudiollc --visibility all
-```
+`CLAUDE_CODE_OAUTH_TOKEN` is provisioned per-repo by Claude Code CLI's `/install-github-app` slash command. There is no `--org` flag and no org-level installation. Two cases:
 
-Without this, every workflow scaffolded from the template will fail on first run. Check `gh secret list --org nightowlstudiollc` before declaring done.
+- **Every existing nightowl repo:** Andrew's working baseline is that the App is already installed everywhere. Confirm with `claude-review-audit.sh` — any nightowl repo lacking the secret is a one-off gap to fix by running `/install-github-app` from a Claude Code CLI session in that repo.
+- **The newly-bootstrapped `nightowlstudiollc/.github` repo itself:** the App did not auto-install, since the repo was created in this session. Run `/install-github-app` against it specifically before the `claude.yml` (`@claude` mention handler) inside it can fire.
+
+When a repo later scaffolds the Claude Blocking Review template via the picker, the workflow only runs cleanly if `/install-github-app` has already been run against that repo. The `.github` repo's existence does not propagate the secret to consumers — it just makes the picker stub available.
 
 ### Phase 4 — Bellwether
 
@@ -105,7 +106,7 @@ If the template doesn't show up in the picker: check that the `.github` repo is 
 
 | Risk | Mitigation |
 |---|---|
-| Template appears in picker but secret missing → first run fails | Phase 3 explicit; verify with `gh secret list --org nightowlstudiollc` |
+| Template appears in picker but secret missing on the consuming repo → first run fails | Phase 3 explicit; `claude-review-audit.sh` is the per-repo check. Remediate with `/install-github-app` on the repo. |
 | Free-tier features (auto-merge, branch protection rules) silently no-op on the `.github` repo if it lands on the wrong tier | NightOwl is on `team` plan per `gh api orgs/nightowlstudiollc`; no concern. Cross-check anyway |
 | `profile/README.md` placeholder gets indexed before real content lands | Land Phase 2 commits in one PR or one direct push, not piecemeal |
 | Existing nightowl repos with bespoke claude-review configs collide with the new template at install time | The template only affects *new* installs. Existing repos are bulk-install territory and untouched by this plan |

--- a/docs/plans/2026-04-30-required-workflows-nightowlstudiollc.md
+++ b/docs/plans/2026-04-30-required-workflows-nightowlstudiollc.md
@@ -44,7 +44,7 @@ Recommend **Audit-only first**, then **Moderate**, escalating to **Strong** only
 
   Recommend **A** until smartwatermelon goes private or NightOwl needs divergent thresholds.
 
-- `CLAUDE_CODE_OAUTH_TOKEN` provisioned at org level (Phase 3 of the defaults plan).
+- `CLAUDE_CODE_OAUTH_TOKEN` present on every repo in the ruleset's scope (per-repo via `/install-github-app` — there is no org-level scope). The defaults plan's Phase 3 verifies this fleet-wide.
 - Org admin permission to create rulesets (`admin:org` scope on `gh` token; check with `gh auth status`).
 - Decision recorded: which gate strength tier to start at.
 


### PR DESCRIPTION
## Summary

Two stale references in the nightowl plan docs claimed `CLAUDE_CODE_OAUTH_TOKEN` could/should be provisioned at the org level via `gh secret set --org`. That's incorrect on two axes:

1. The `gh` token I run as does not have `admin:org` (and won't be granted it).
2. More fundamentally: there is no org-level `/install-github-app` scope. The token is provisioned per-repo by Claude Code CLI's `/install-github-app` slash command. The expectation is that every repo Andrew owns already has the GitHub App installed; a missing secret on a specific repo is a remediation gap surfaced by `claude-review-audit.sh`, not an org-level config item.

Audit run during this session confirms: 30 repos scanned, only 2 issues across the entire fleet, only 1 of those is a missing-secret case (`nightowlstudiollc/.github`, which I just bootstrapped — App auto-install hadn't fired yet).

This PR rewrites:

- **`2026-04-30-create-nightowlstudiollc-github-defaults.md`** — Phase 3 ("Provision org-level secret") replaced with "Verify the GitHub App is installed on target repos." Preconditions and risks table updated to match.
- **`2026-04-30-required-workflows-nightowlstudiollc.md`** — preconditions reference per-repo provisioning instead of the deleted org-level Phase 3.

A parallel PR fixes the same incorrect text in `nightowlstudiollc/.github/CLAUDE.md`.

## Test plan

- [x] markdownlint passes
- [x] No remaining `gh secret set --org` references in `docs/plans/`
- [x] Cross-references between plan docs still resolve
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)