### PR TITLE
chore: ignore smartwatermelon/headroom in claude-review-audit

### DIFF
--- a/.claude-review-ignore
+++ b/.claude-review-ignore
@@ -6,3 +6,4 @@
 # Use this for repos that should never have the review installed.
 
 nightowlstudiollc/networth-agent
+smartwatermelon/headroom


### PR DESCRIPTION
## Summary
- Add `smartwatermelon/headroom` to `.claude-review-ignore`. It's a fork; not a candidate for the blocking review.

After this lands, the only remaining audit-flagged repos are:
- `smartwatermelon/scripts` — free-tier limitation (per memory; can't add required-status-checks on free repos)
- `nightowlstudiollc/.github` — the org's own defaults repo, which intentionally hosts the org-level workflow rather than running it on its own PRs

## Test plan
- [x] `claude-review-audit.sh` confirms headroom moves to "Ignored repos" section
- [x] No code changes; config-file only

🤖 Generated with [Claude Code](https://claude.com/claude-code)