### PR TITLE
feat: minimize PASS review comments via GraphQL

### DIFF
--- a/.github/workflows/claude-blocking-review.yml
+++ b/.github/workflows/claude-blocking-review.yml
@@ -552,3 +552,69 @@ jobs:
             echo "**Verdict:** UNKNOWN (unexpected format — defaulting to PASS)" >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
+
+      - name: Minimize PASS review comment
+        if: always() && steps.doc-check.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          # Minimize PASS comments so downstream scrapers (post-push-status.sh
+          # and similar tooling) don't treat them as unresolved findings. BLOCK
+          # comments must remain visible — humans need to act on them. The
+          # comment body is preserved in the PR thread under a collapsed
+          # "Resolved" disclosure, so the audit trail is intact.
+
+          # Skip if the [skip-claude-review] escape hatch was used.
+          PR_BODY=$(gh pr view "$PR_NUMBER" --json body -q .body 2>/dev/null || echo "")
+          if echo "$PR_BODY" | grep -qE '\[skip-claude-review(\]|:)'; then
+            echo "[skip-claude-review] override active — nothing to minimize."
+            exit 0
+          fi
+
+          VERDICT_FILE="/tmp/review-verdict.txt"
+          if [ ! -f "$VERDICT_FILE" ]; then
+            echo "No verdict file — nothing to minimize."
+            exit 0
+          fi
+          if ! head -1 "$VERDICT_FILE" | grep -q "VERDICT: PASS"; then
+            echo "Verdict is not PASS — leaving comment visible."
+            exit 0
+          fi
+
+          OWNER="${REPO%/*}"
+          NAME="${REPO#*/}"
+
+          # Locate the just-posted claude-blocking-review comment for this exact
+          # SHA. `last: 20` is plenty — the comment was posted seconds ago.
+          COMMENT_ID=$(gh api graphql \
+            -f query='query($owner: String!, $name: String!, $number: Int!) {
+              repository(owner: $owner, name: $name) {
+                pullRequest(number: $number) {
+                  comments(last: 20) {
+                    nodes { id body isMinimized }
+                  }
+                }
+              }
+            }' \
+            -f owner="$OWNER" -f name="$NAME" -F number="$PR_NUMBER" \
+            --jq ".data.repository.pullRequest.comments.nodes[] | select(.isMinimized == false) | select(.body | startswith(\"<!-- claude-blocking-review sha=$SHA\")) | .id" \
+            2>/dev/null | head -1)
+
+          if [ -z "$COMMENT_ID" ]; then
+            echo "No PASS comment found for SHA $SHA — nothing to minimize (the bot may have failed to post)."
+            exit 0
+          fi
+
+          # classifier: RESOLVED is the right semantics — the issue raised by
+          # the reviewer (whether to BLOCK) was resolved with a PASS verdict.
+          # OUTDATED would be wrong (the verdict isn't stale, it's settled).
+          if gh api graphql \
+              -f query='mutation($id: ID!) { minimizeComment(input: {subjectId: $id, classifier: RESOLVED}) { clientMutationId } }' \
+              -f id="$COMMENT_ID" >/dev/null 2>&1; then
+            echo "Minimized PASS comment $COMMENT_ID."
+          else
+            echo "::warning::Failed to minimize PASS comment $COMMENT_ID — non-fatal."
+          fi


### PR DESCRIPTION
## Problem

The CI-side `claude-blocking-review` workflow posts a PR comment for every review — PASS or BLOCK. The local `post-push-status.sh` tool scrapes bot comments to surface unresolved findings but has no way to distinguish PASS verdicts from BLOCK findings on its own. Result: every PASS comment gets surfaced as a phantom "finding" in the post-push loop, drowning out real signals.

## Fix

Add a new workflow step IMMEDIATELY AFTER "Check review verdict". When the verdict is PASS, the step locates the just-posted `claude-blocking-review` comment for the current SHA (matched via the `<!-- claude-blocking-review sha=<HEAD_SHA> ... -->` marker) and minimizes it via GraphQL `minimizeComment(classifier: RESOLVED)`.

BLOCK comments are NOT minimized — humans need to act on them. The audit trail is preserved either way: the comment body stays in the PR thread under the standard "Resolved" disclosure.

Design choices:
- `if: always()` so the step runs even after the verdict-check step exits 0 normally.
- All non-PASS / no-verdict / no-comment paths short-circuit cleanly with `exit 0` (non-fatal).
- `[skip-claude-review]` escape hatch is honored (no comment to minimize when the bot didn't run).
- `classifier: RESOLVED` is the right semantics — the verdict is settled, not stale (which would be `OUTDATED`).
- Pattern mirrors the existing "Minimize prior review comments" step at lines 283-335 (same `gh api graphql` idiom, same `-f` / `-F` flags, same `--jq` filter style).

## Coordinating work

A separate PR in `claude-config` will teach `post-push-status.sh` to skip minimized comments via the GraphQL `isMinimized` field. That work is out of scope for this PR — this PR is purely the workflow-side change.

## CI behavior on this PR

The CI `claude-review` will SKIP automatically due to the workflow-self-modification protection (lines 154-175 in this same workflow file): the `anthropics/claude-code-action` refuses to run against a PR that modifies its own workflow file. That's by design and is documented in those lines. Local pre-commit and pre-push reviewers ran cleanly (code-reviewer + adversarial-reviewer + full-diff codebase review all PASS).

## Test plan

- [x] `yamllint .github/workflows/claude-blocking-review.yml` — only pre-existing line-length warnings on lines that mirror the existing pattern; no errors
- [x] Visual diff matches the template in the task brief
- [x] Local pre-commit reviewers PASS
- [x] Local pre-push full-diff + codebase review PASS
- [ ] On the next non-workflow PR after merge, watch for a PASS comment getting collapsed in the PR conversation