### PR TITLE
fix(ci): remove issues trigger cascade + add dependabot fast-pass

### DIFF
--- a/.github/workflows/claude-assistant.yml
+++ b/.github/workflows/claude-assistant.yml
@@ -11,8 +11,7 @@ name: Claude Code Assistant
 #       if: |
 #         (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
 #         (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
-#         (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)) ||
-#         (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association))
+#         (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association))
 #       permissions:
 #         contents: read
 #         issues: read

--- a/.github/workflows/claude-blocking-review.yml
+++ b/.github/workflows/claude-blocking-review.yml
@@ -221,9 +221,22 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Check for Dependabot PR
+        id: dependabot-check
+        if: steps.doc-check.outputs.skip != 'true'
+        run: |
+          if [ "${{ github.actor }}" = "dependabot[bot]" ]; then
+            echo "::notice::Dependabot PR — skipping AI review (version bumps are low-risk)."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "## Claude Code Review" >> "$GITHUB_STEP_SUMMARY"
+            echo "**Verdict:** SKIPPED (Dependabot version bump)" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Estimate review parameters
         id: estimate
-        if: steps.doc-check.outputs.skip != 'true'
+        if: steps.doc-check.outputs.skip != 'true' && steps.dependabot-check.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ inputs.pr_number }}
@@ -281,7 +294,7 @@ jobs:
           echo "| Timeout | ${TIMEOUT}m |" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Minimize prior review comments
-        if: steps.doc-check.outputs.skip != 'true'
+        if: steps.doc-check.outputs.skip != 'true' && steps.dependabot-check.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
@@ -336,7 +349,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        if: steps.doc-check.outputs.skip != 'true'
+        if: steps.doc-check.outputs.skip != 'true' && steps.dependabot-check.outputs.skip != 'true'
         timeout-minutes: ${{ fromJSON(steps.estimate.outputs.timeout_minutes) }}
         continue-on-error: true  # infrastructure failure must not block merges
         uses: anthropics/claude-code-action@26ec041249acb0a944c0a47b6c0c13f05dbc5b44  # v1
@@ -475,11 +488,17 @@ jobs:
           PR_NUMBER: ${{ inputs.pr_number }}
           CLAUDE_OUTCOME: ${{ steps.claude-review.outcome }}
           DOC_SKIP: ${{ steps.doc-check.outputs.skip }}
+          DEPENDABOT_SKIP: ${{ steps.dependabot-check.outputs.skip }}
         run: |
           # Short-circuit: doc-only diff already wrote its summary in the
           # Check for doc-only diff step. Nothing to verify, nothing to block.
           if [ "$DOC_SKIP" = "true" ]; then
             echo "Doc-only skip — no verdict required."
+            exit 0
+          fi
+
+          if [ "$DEPENDABOT_SKIP" = "true" ]; then
+            echo "Dependabot skip — no verdict required."
             exit 0
           fi
 
@@ -554,7 +573,7 @@ jobs:
           fi
 
       - name: Minimize PASS review comment
-        if: always() && steps.doc-check.outputs.skip != 'true'
+        if: always() && steps.doc-check.outputs.skip != 'true' && steps.dependabot-check.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -5,8 +5,6 @@ on:
     types: [created]
   pull_request_review_comment:
     types: [created]
-  issues:
-    types: [opened, assigned]
   pull_request_review:
     types: [submitted]
 
@@ -15,8 +13,7 @@ jobs:
     if: |
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association))
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association))
     permissions:
       contents: read
       issues: read


### PR DESCRIPTION
## Summary

- **Remove `issues` trigger from `claude.yml`**: The `issues: [opened, assigned]` event trigger was causing cascading Claude invocations whenever Ralph or Dependabot created issues. Each issue opened would fire the workflow, burn Anthropic API credits, and produce no useful output (Claude has nothing actionable to do on a newly-opened issue from a bot). Removed the trigger and its corresponding `if:` condition.

- **Add Dependabot fast-pass to `claude-blocking-review.yml`**: When `github.actor == dependabot[bot]`, skip the paid Claude review entirely. Version bumps are low-risk, and `claude-code-action` already refuses to run on PRs that modify workflow files (which covers Dependabot's action-pin bumps). The fast-pass is inserted after the doc-only check and before parameter estimation, so all downstream steps (review, comment minimize, verdict check) are properly short-circuited.

- **Update `claude-assistant.yml` caller documentation**: Removed the `issues` line from the example `if:` block so consumer repos copying the template don't re-introduce the trigger.

## Motivation

Part of the Anthropic spend reduction initiative. These two changes eliminate the highest-volume sources of wasted Claude invocations across all repos that consume these reusable workflows.

## Test plan

- [ ] Verify CI passes on this PR (the blocking review workflow will run against this PR itself)
- [ ] Confirm the YAML is valid (yamllint runs in pre-commit)
- [ ] After merge, verify Dependabot PRs in consumer repos show "SKIPPED (Dependabot version bump)" in the job summary instead of running a full Claude review
- [ ] After merge, verify new issues no longer trigger the Claude assistant workflow