### PR TITLE
feat(scripts): add new-smartwatermelon-repo.sh one-command bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,41 @@ blocking-review workflow doesn't gate its own install/bump PR.
 For `nightowlstudiollc`, this script is intentionally not used — that org gets
 the workflow-templates picker via [`nightowlstudiollc/.github`](https://github.com/nightowlstudiollc/.github)
 (mirrors `smartwatermelon/.github` workflow-templates; verified appearing under
-"By Night Owl Studio" in the Actions → New workflow UI), and (planned)
-Repository Rulesets for org-wide enforcement.
+"By Night Owl Studio" in the Actions → New workflow UI). Repository Rulesets
+for org-wide enforcement were attempted once and rolled back (see
+`docs/plans/2026-04-30-required-workflows-nightowlstudiollc.md`); a
+re-attempt is deliberately not planned here and would need its own review
+given that history.
+
+## New-repo bootstrap script (`smartwatermelon` only)
+
+`new-smartwatermelon-repo.sh` is the creation-time counterpart to the
+bulk-install script above — for a genuinely *new* `smartwatermelon` repo,
+rather than retrofitting an existing one. `smartwatermelon` being a User
+account means it can't use GitHub's org-only workflow-templates picker
+*or* Repository Rulesets to auto-attach anything on repo creation, so this
+script is the closest available approximation: one command instead of
+"create repo, then remember to run the bulk-install script, then remember
+the one repo setting no template can seed."
+
+```bash
+./new-smartwatermelon-repo.sh <name> [--private]
+```
+
+This does three things:
+
+1. `gh repo create <name> --template smartwatermelon/repo-template` — a
+   real [GitHub template repository](https://github.com/smartwatermelon/repo-template)
+   containing caller stubs for `claude.yml`, `claude-code-review.yml`,
+   `dependabot-auto-merge.yml`, and a `.github/dependabot.yml`. Template
+   repos are a general GitHub feature, not gated to Organizations, so this
+   part genuinely works the same for a User account as it would for an Org.
+2. Sets `can_approve_pull_request_reviews: true` via the Actions API — the
+   one setting a template repo cannot seed, and the exact fix from issue
+   [#87](https://github.com/smartwatermelon/github-workflows/issues/87).
+3. Prints a reminder for the one step that can't be scripted at all: run
+   `/install-github-app` from Claude Code (or add the
+   `CLAUDE_CODE_OAUTH_TOKEN` secret manually) so the Claude workflows can
+   actually run.
 
 Plan: `docs/plans/2026-04-30-bulk-install-smartwatermelon-fleet.md`.

--- a/new-smartwatermelon-repo.sh
+++ b/new-smartwatermelon-repo.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# new-smartwatermelon-repo.sh
+#
+# One-command bootstrap for new smartwatermelon/* repos. Part C of the fleet
+# reusable-workflows plan: smartwatermelon is a User account, so it can't use
+# GitHub's org-only workflow-templates picker or Repository Rulesets to
+# auto-attach workflows on repo creation. `gh repo create --template` is a
+# general repo feature (not org-gated) and gets the workflow files in place
+# at creation time; this script also handles the one repo-setting a template
+# cannot seed (can_approve_pull_request_reviews, needed for
+# dependabot-auto-merge.yml's approval step — see issue #87).
+#
+# What this does NOT do: install the CLAUDE_CODE_OAUTH_TOKEN secret. There is
+# no way to script that — it requires running `/install-github-app` from
+# Claude Code, a one-time interactive step. This script prints a reminder.
+#
+# Usage:
+#   ./new-smartwatermelon-repo.sh <name> [--private]
+#
+# Examples:
+#   ./new-smartwatermelon-repo.sh my-new-thing
+#   ./new-smartwatermelon-repo.sh my-new-thing --private
+
+set -euo pipefail
+
+if [[ "${BASH_VERSINFO[0]}" -lt 4 ]]; then
+  printf "Error: bash 4.0+ required (found %s). Run as: ./%s\n" \
+    "${BASH_VERSION}" "${0##*/}" >&2
+  exit 1
+fi
+
+TEMPLATE="smartwatermelon/repo-template"
+OWNER="smartwatermelon"
+
+usage() {
+  printf "Usage: %s <name> [--private]\n" "${0##*/}" >&2
+  exit 1
+}
+
+[[ $# -ge 1 ]] || usage
+NAME="$1"
+shift
+
+VISIBILITY="--public"
+if [[ "${1:-}" == "--private" ]]; then
+  VISIBILITY="--private"
+fi
+
+REPO="${OWNER}/${NAME}"
+
+echo "==> Creating ${REPO} from ${TEMPLATE} (${VISIBILITY#--})"
+gh repo create "${REPO}" --template "${TEMPLATE}" "${VISIBILITY}"
+
+echo "==> Setting can_approve_pull_request_reviews=true (required for dependabot-auto-merge.yml)"
+gh api -X PUT "repos/${REPO}/actions/permissions/workflow" \
+  -F can_approve_pull_request_reviews=true \
+  -f default_workflow_permissions=read
+
+echo ""
+echo "==> ${REPO} created and configured. One manual step remains:"
+echo ""
+echo "    Run /install-github-app from Claude Code (or add the"
+echo "    CLAUDE_CODE_OAUTH_TOKEN secret manually under Settings ->"
+echo "    Secrets and variables -> Actions) so claude.yml and"
+echo "    claude-code-review.yml can run."
+echo ""
+echo "    Optional: add 'claude-review / run-review' as a required"
+echo "    status check under Settings -> Branches."


### PR DESCRIPTION
## Summary

Part C of the fleet reusable-workflows plan (see `~/.claude/plans/glittery-percolating-mist.md`). `smartwatermelon` is a User account, so it can't use GitHub's org-only workflow-templates picker or Repository Rulesets to auto-attach anything on repo creation. This closes that gap with the best available mechanism: a real GitHub template repo (`smartwatermelon/repo-template`, already created and flagged) plus a wrapper script that also sets the one repo setting a template can't seed.

## What's new

- `new-smartwatermelon-repo.sh` — `gh repo create --template smartwatermelon/repo-template`, then sets `can_approve_pull_request_reviews=true` (issue #87), then prints a reminder that `CLAUDE_CODE_OAUTH_TOKEN` still needs a manual `/install-github-app` run (no way to script that).
- `smartwatermelon/repo-template` (separate repo, already live) ships `claude.yml`, `claude-code-review.yml`, `dependabot-auto-merge.yml`, `.github/dependabot.yml`, and a starter `CLAUDE.md`.
- README: new section documenting the script, plus a correction to a stale line that called the NightOwl Repository Ruleset "(planned)" — that rollout was attempted and rolled back; a re-attempt isn't currently planned.

## Verification

Ran the script end-to-end against a real disposable test repo (`smartwatermelon/zz-test-delete-me`, private): confirmed all three workflow files and `dependabot.yml` landed via the template, and confirmed `can_approve_pull_request_reviews` was set correctly via the API afterward. Test repo pending manual deletion (my token lacks `delete_repo` scope).

`[skip-claude-review: bulk-install]` not needed here — this isn't a fleet-wide install PR, just the script's own repo.