### PR TITLE
fix: validate repo name and reject unrecognized args in new-smartwatermelon-repo.sh

### DIFF
--- a/new-smartwatermelon-repo.sh
+++ b/new-smartwatermelon-repo.sh
@@ -41,9 +41,17 @@ usage() {
 NAME="$1"
 shift
 
+[[ "${NAME}" =~ ^[a-zA-Z0-9_.-]+$ ]] || {
+  printf "Error: invalid repo name '%s' — must match [a-zA-Z0-9_.-]+\n" "${NAME}" >&2
+  usage
+}
+
 VISIBILITY="--public"
 if [[ "${1:-}" == "--private" ]]; then
   VISIBILITY="--private"
+elif [[ -n "${1:-}" ]]; then
+  printf "Error: unrecognized argument '%s'\n" "${1}" >&2
+  usage
 fi
 
 REPO="${OWNER}/${NAME}"


### PR DESCRIPTION
## Summary
- #98: `NAME` is validated against `^[a-zA-Z0-9_.-]+$` before use, so an invalid repo name (slashes, spaces, other special characters) produces a clear usage error instead of a cryptic `gh repo create` API failure.
- #99: an unrecognized second argument (e.g. a typo'd flag like `--Public`) now hits a new `elif` branch that prints an error and calls `usage`, instead of being silently ignored and defaulting to `--public`.

Both fixes live in the same ~15-line argument-parsing block of `new-smartwatermelon-repo.sh` with no interaction risk between them, so bundled into one PR per the "same file, no masking risk" bar.

## Test plan
- [x] `shellcheck -S info new-smartwatermelon-repo.sh` — clean
- [x] Extracted the arg-parsing block into a standalone harness and exercised:
  - valid name, no flag → `--public` (unchanged)
  - valid name, `--private` → `--private` (unchanged)
  - valid name, typo'd flag `--Public` → now errors with usage (previously silently defaulted to public)
  - invalid name with a slash → now errors with usage (previously would have hit `gh repo create` with a cryptic error)
  - no args → usage error (unchanged)
- [x] Local pre-commit and pre-push review hooks (code-reviewer, adversarial-reviewer, full-diff + codebase review) all passed

Closes #98, closes #99.

https://claude.ai/code/session_019yrvtEbtQxBxDmZ4Fu9GrU