### PR TITLE
fix: strip comments before checkout/secrets-inherit greps in audit script

### DIFF
--- a/claude-review-audit.sh
+++ b/claude-review-audit.sh
@@ -196,15 +196,27 @@ check_repo() {
         # `actions/checkout` or `secrets: inherit` would actually be added).
         # This does not block or gate anything — it only surfaces in the
         # audit report, matching the rest of this script's behavior.
-        if echo "${raw}" | grep -q "actions/checkout"; then
+        #
+        # Operate on comment-stripped content and anchor to the `uses:`
+        # form, matching self-review.yml's guard-no-checkout job (#97) —
+        # a raw/unanchored grep would false-positive on a caller stub that
+        # merely mentions "actions/checkout" or "secrets: inherit" in a
+        # comment (e.g. a warning not to add them).
+        local stripped
+        stripped=$(strip_comments "${raw}")
+        local has_checkout=false has_secrets_inherit=false
+        echo "${stripped}" | grep -qE 'uses:[[:space:]]*actions/checkout' && has_checkout=true
+        echo "${stripped}" | grep -qE 'secrets:[[:space:]]*inherit' && has_secrets_inherit=true
+
+        if [[ "${has_checkout}" == true ]]; then
           fail "Caller stub ${wf} references dependabot-auto-merge.yml AND contains actions/checkout"
           issues+=("SECURITY: remove actions/checkout from ${wf} — dependabot-auto-merge.yml uses pull_request_target and must never check out PR code (see #64)")
         fi
-        if echo "${raw}" | grep -q "secrets:[[:space:]]*inherit"; then
+        if [[ "${has_secrets_inherit}" == true ]]; then
           fail "Caller stub ${wf} references dependabot-auto-merge.yml AND uses secrets: inherit"
           issues+=("SECURITY: remove 'secrets: inherit' from ${wf} — dependabot-auto-merge.yml needs no repo secrets; inherit hands every repo secret to a pull_request_target job evaluating external PR content")
         fi
-        if ! echo "${raw}" | grep -q "actions/checkout" && ! echo "${raw}" | grep -q "secrets:[[:space:]]*inherit"; then
+        if [[ "${has_checkout}" == false && "${has_secrets_inherit}" == false ]]; then
           ok "Dependabot auto-merge caller: ${wf} (no checkout, no secrets: inherit)"
         fi
       fi


### PR DESCRIPTION
## Summary
- The dependabot-auto-merge caller-stub security checks in `claude-review-audit.sh` (`actions/checkout` and `secrets: inherit` detection, around line 199) operated on raw, unstripped file content — unlike the outer `uses_dependabot_auto_merge()` gate, which already strips comments via `strip_comments()`.
- A caller stub containing a warning comment like `# do not add actions/checkout here` alongside a legitimate caller reference would trip a false-positive SECURITY finding.
- Now strips comments first, and anchors the checkout pattern to `uses:\s*actions/checkout` — matching the exact convention already used by `self-review.yml`'s `guard-no-checkout` job for the reusable workflow's own copy of the file.

## Test plan
- [x] `shellcheck -S info claude-review-audit.sh` — clean
- [x] Extracted the check logic into a standalone harness and exercised four synthetic caller stubs:
  - comment-only mention of `actions/checkout` → now clean (previously a false positive)
  - real `actions/checkout` step present → still flagged
  - real `secrets: inherit` present → still flagged
  - clean caller stub → still clean
- [x] Local pre-commit and pre-push review hooks (code-reviewer, adversarial-reviewer, full-diff + codebase review) all passed

This is a read-only audit script (makes no changes, only reports), so the blast radius of a bug here is a wrong report line, not an actual security gap — but the false positive was worth fixing since it would erode trust in the audit output.

Closes #97 (canonical issue; #95 was closed as a duplicate of this one).

https://claude.ai/code/session_019yrvtEbtQxBxDmZ4Fu9GrU