### PR TITLE
fix: warn on too-short sha= marker in Minimize PASS review comment step

### DIFF
--- a/.github/workflows/claude-blocking-review.yml
+++ b/.github/workflows/claude-blocking-review.yml
@@ -675,7 +675,14 @@ jobs:
             if [ -z "$MARKER_SHA" ]; then
               echo "[skip-claude-review] unscoped override active — nothing to minimize."
               exit 0
-            elif [ "${#MARKER_SHA}" -ge 7 ] && [ "${SHA#"$MARKER_SHA"}" != "$SHA" ]; then
+            elif [ "${#MARKER_SHA}" -lt 7 ]; then
+              # Mirrors the "Check review verdict" step's rejection of
+              # too-short sha= values (#92) — log the same warning here so
+              # an operator debugging why a PASS comment wasn't minimized
+              # sees the same too-short-marker explanation in both steps'
+              # logs, instead of this step silently falling through.
+              echo "::warning::[skip-claude-review sha=${MARKER_SHA}] marker rejected — sha= value must be at least 7 characters. Proceeding with minimize check."
+            elif [ "${SHA#"$MARKER_SHA"}" != "$SHA" ]; then
               echo "[skip-claude-review sha=${MARKER_SHA}] override active for current head — nothing to minimize."
               exit 0
             fi


### PR DESCRIPTION
## Summary
- The "Check review verdict" step already warns and logs when a `[skip-claude-review sha=...]` marker's `sha=` value is too short (<7 chars) to trust, then proceeds with review.
- The "Minimize PASS review comment" step had no equivalent branch for the same too-short case — it silently fell through to the minimize logic with no log message, creating a behavioral asymmetry between the two steps that made them harder to reason about together when debugging.
- Adds the missing `elif` branch: a too-short `MARKER_SHA` now logs the same `::warning::` as the verdict step, then falls through to the minimize logic (matching the verdict step's "reject and proceed" behavior) instead of silently doing nothing.

## Test plan
- [x] Extracted the logic into a standalone harness and exercised all five marker states: no marker, unscoped marker, too-short scoped marker (now warns + falls through), scoped marker matching head (skips, unchanged), scoped marker not matching head (falls through silently, unchanged — this is a distinct case that correctly has no warning, matching the verdict step's precedent of only warning on the too-short/invalid case)
- [x] `yamllint` — clean (pre-existing line-length warnings unrelated to this diff)
- [x] Committed with `SKIP=zizmor` per the documented escape hatch (dotfiles `pre-commit/config.yaml`, PR #155): zizmor lints the whole file and this file carries pre-existing findings (`template-injection`, `known-vulnerable-actions`, `ref-version-mismatch` x2, `artipacked`) unrelated to this diff. Confirmed identical finding count/type present on `main` before this change — this diff introduces zero new findings. Given this repo's wide fleet-wide blast radius and the ask to keep fixes narrowly scoped, those pre-existing findings are out of scope here and warrant their own dedicated triage.
- [x] Local pre-commit and pre-push review hooks (code-reviewer, adversarial-reviewer, full-diff + codebase review) all passed

Closes #92.

https://claude.ai/code/session_019yrvtEbtQxBxDmZ4Fu9GrU