### PR TITLE
docs(readme): add zizmor suppression comment to caller-stub example

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ for manual review.
 ```yaml
 name: Dependabot Auto-Merge
 
-on:
+on: # zizmor: ignore[dangerous-triggers] required to run from base branch; no PR code executed here
   pull_request_target:
     types: [opened, synchronize, reopened]
 


### PR DESCRIPTION
## Summary
Every caller stub needs a `zizmor: ignore[dangerous-triggers]` comment on its `on: pull_request_target` trigger now that the zizmor pre-commit hook is blocking fleet-wide (dev-env#19) — without it, the hook fires on every migration commit. Discovered while canary-testing the v2 migration on `repo-template` (dev-env#20, see smartwatermelon/repo-template#3); folding the fix into the README so the other 30 caller-repo migrations copy a correct template instead of hitting this 30 more times.

## Test plan
- [x] Verified against the actual canary migration (repo-template#3) — same fix applied there, confirmed it clears the zizmor `dangerous-triggers` finding while leaving the (intentionally accepted) `unpinned-uses` finding on the reusable-workflow reference

https://claude.ai/code/session_01Q5QrbCLnJdAPjcCLu9UHNp