### PR TITLE
docs(readme): gate claude-code-review caller at github.actor to skip Dependabot

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,14 @@ on:
 
 jobs:
   claude-review:
+    # Dependabot PRs run under a restricted token with no repo-secret
+    # access. If this job dispatches for one anyway, GitHub can't satisfy
+    # the reusable workflow's required `claude_oauth_token` secret and the
+    # whole run fails with startup_failure BEFORE any step — including the
+    # reusable workflow's own in-job Dependabot fast-pass — gets to run.
+    # Gate at the caller so the secret is never referenced in a context
+    # that can't supply it. See smartwatermelon/github-workflows#115.
+    if: github.actor != 'dependabot[bot]'
     uses: YOUR_ORG/github-workflows/.github/workflows/claude-blocking-review.yml@v3
     with:
       pr_number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary
Fixes #115: every Dependabot PR fleet-wide currently hits a `startup_failure` on the `claude-code-review.yml` → `claude-blocking-review.yml` chain. Root cause: the reusable workflow's `secrets.claude_oauth_token` is `required: true`, and GitHub validates that contract at dispatch time — before any job or step runs. Dependabot's restricted token context can't supply repo secrets, so the run fails to start entirely, and the reusable workflow's own in-job Dependabot fast-pass (`dependabot-check` step) never gets a chance to fire, since the job it lives in never starts.

Fix: gate the caller job itself with `if: github.actor != 'dependabot[bot]'`, so the secret is never referenced in a context that can't supply it.

Confirmed live on `smartwatermelon/repo-template` PR #1 — same failure signature (`startup_failure`, `jobs: []`, `billable: {}`) reproduced on both 2026-08-07 and 2026-08-11, predating and unrelated to today's dependabot-auto-merge v2 work on that same PR.

## Next steps
This needs to land in every consuming repo's `claude-code-review.yml` (or equivalent), not just the README template — likely the same ~31 repos touched by the dependabot-auto-merge v2 migration (dev-env#20), since they share the caller-stub pattern. Plan is to bundle both fixes into a single PR per repo rather than two separate waves.

## Test plan
- [x] markdownlint clean
- [x] Local pre-push review (adversarial + codebase) confirmed the diagnosis and fix reasoning are accurate
- [ ] Verify on the first real caller-repo migration that `if: github.actor != 'dependabot[bot]'` actually prevents the startup_failure (this PR only updates the README template, not any live caller)

https://claude.ai/code/session_01Q5QrbCLnJdAPjcCLu9UHNp