### PR TITLE
fix(dependabot-auto-merge): close whitespace-only DEP_NAMES bypass, document namespace limits

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -95,6 +95,11 @@ on:
           trailing slash) that are auto-mergeable on a MAJOR version
           bump. dependabot and actions are always trusted; add your
           own org here, e.g. 'smartwatermelon' or 'nightowlstudiollc'.
+          Only matches 'namespace/name'-style dependency names (GitHub
+          Actions org/repo, npm scoped packages like '@scope/name').
+          Unscoped package-manager deps (npm 'lodash', PyPI 'requests',
+          etc. with no slash) never match and always fall through to
+          manual review on a major bump, regardless of this allowlist.
         type: string
         required: false
         default: ''
@@ -180,9 +185,14 @@ jobs:
               exit 0
             fi
           fi
-          # Fail closed if dependency-names is missing — we cannot apply
-          # the trusted-namespace allowlist without it.
-          if [ -z "${DEP_NAMES:-}" ]; then
+          # Fail closed if dependency-names is missing or whitespace-only —
+          # we cannot apply the trusted-namespace allowlist without it.
+          # Checking dep_count (already trimmed/normalized above) rather
+          # than the raw DEP_NAMES string catches a whitespace-only value
+          # (e.g. "  "), which would otherwise pass this guard, then have
+          # the namespace-allowlist path below trim it to an empty
+          # remainder and incorrectly decide "merge".
+          if [ "$dep_count" -eq 0 ]; then
             echo "decision=skip" >> "$GITHUB_OUTPUT"
             echo "::notice::Empty dependency-names ($PREV_VERSION -> $NEW_VERSION); leaving for manual review"
             exit 0


### PR DESCRIPTION
## Summary
- Fail-closed guard now checks the normalized `dep_count` instead of the raw `DEP_NAMES` string, so a whitespace-only `dependency-names` output from `fetch-metadata` can no longer fall through to the namespace-allowlist path and incorrectly auto-merge
- Documented that `trusted_namespaces` only matches `namespace/name`-style dependency names and never applies to unscoped package-manager deps like npm `lodash` or PyPI `requests`

Closes #110, #108.

## Test plan
- [x] Manually verified whitespace-only `DEP_NAMES="   "` now yields `dep_count=0` and triggers fail-closed skip
- [x] `zizmor` clean, `yamllint` clean
- [x] Local pre-push review (adversarial + codebase) passed

https://claude.ai/code/session_018nKcnJLyMNSvfFZ9up4JLb
