### PR TITLE
fix(security): bump claude-code-action to v1.0.193 (GHSA-8q5r-mmjf-575q)

### DIFF
--- a/.github/workflows/claude-assistant.yml
+++ b/.github/workflows/claude-assistant.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@26ec041249acb0a944c0a47b6c0c13f05dbc5b44 # v1
+        uses: anthropics/claude-code-action@9d7150bc8a3dae8149739a88019d192b579ad90c # v1.0.193
         with:
           # claude-code-action rejects non-User actors unless explicitly allowed.
           # The caller's author_association guard (OWNER/MEMBER/COLLABORATOR) is

--- a/.github/workflows/claude-blocking-review.yml
+++ b/.github/workflows/claude-blocking-review.yml
@@ -433,7 +433,7 @@ jobs:
         if: steps.doc-check.outputs.skip != 'true' && steps.dependabot-check.outputs.skip != 'true'
         timeout-minutes: ${{ fromJSON(steps.estimate.outputs.timeout_minutes) }}
         continue-on-error: true  # infrastructure failure must not block merges
-        uses: anthropics/claude-code-action@26ec041249acb0a944c0a47b6c0c13f05dbc5b44  # v1
+        uses: anthropics/claude-code-action@9d7150bc8a3dae8149739a88019d192b579ad90c  # v1.0.193
         with:
           # claude-code-action rejects non-User actors unless explicitly allowed.
           # Callers use this on pull_request events that fire for bot-opened PRs


### PR DESCRIPTION
Part 1 of #123 — the advisory fix, shipped ahead of items 2-4 per the issue's suggested sequencing.

## What

Bumps `anthropics/claude-code-action` in both reusable workflows from `26ec0412` (v1.0.70) to `9d7150bc` (v1.0.193).

- `.github/workflows/claude-assistant.yml:80`
- `.github/workflows/claude-blocking-review.yml:436`

## Why

[GHSA-8q5r-mmjf-575q](https://github.com/advisories/GHSA-8q5r-mmjf-575q) (medium) — malicious MCP server configuration in PRs enables RCE and secret exfiltration. Vulnerable `< 1.0.74`.

Both workflows run with `id-token: write` and receive `CLAUDE_CODE_OAUTH_TOKEN`, and are consumed fleet-wide via floating tags, so the vulnerable pin was live in ~30 repos.

## Correction to the issue's proposed SHA

The issue proposes pinning to `d07835ac7037978eb1aa67c6be18ed0883cea652`. **That is not a commit** — it's the annotated tag object for the floating `v1` tag, so Actions would fail to resolve it:

```console
$ gh api repos/anthropics/claude-code-action/git/ref/tags/v1 --jq '{type:.object.type, sha:.object.sha}'
{"sha":"d07835ac7037978eb1aa67c6be18ed0883cea652","type":"tag"}

$ gh api repos/anthropics/claude-code-action/git/tags/d07835ac... --jq '{tag:.tag, commit:.object.sha}'
{"commit":"9d7150bc8a3dae8149739a88019d192b579ad90c","tag":"v1"}
```

`9d7150bc` is the dereferenced commit and is the immutable `v1.0.193` semver tag — that's what this PR pins to.

## Compatibility

Diffed `action.yml` between the two SHAs: **no inputs removed** (additive only). All inputs these workflows pass — `claude_code_oauth_token`, `allowed_bots`, `additional_permissions`, `prompt` — are still declared in v1.0.193.

## Scope notes

- Also resolves the two `# v1` stale version comments from **item 3** as a side effect.
- **Items 2-4 deliberately not addressed here** — they ride a later cleanup tag.
- Committed with `SKIP=zizmor` (human-authorized): all 5 blocking zizmor findings are pre-existing items 2-4, none introduced by this change. `zizmor` no longer reports anything against the `claude-code-action` pins.

## Rollout

Per `README.md:270` this wants a new tag piloted on 2-3 low-traffic repos before repointing the floating `v3`/`v1` tags. Not done in this PR.

Refs #123

https://claude.ai/code/session_01SimcNSM4P5hpb1dQVejqcF