### PR TITLE
chore(ci): add dependabot.yml to watch third-party action pins

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+# Dependabot: auto-PR bumps for GitHub Actions pins in .github/workflows/.
+# Primary target: anthropics/claude-code-action, pinned inside this repo's
+# reusable workflows and inherited fleet-wide through the floating v1/v3 tags.
+# Secondary: any other actions/* or third-party actions used here.
+#
+# Matches the fleet-standard config (dotfiles, claude-config, dev-env, ...)
+# with one deliberate difference: no `cooldown`. Consumer repos delay bumps
+# to let a release settle, but this repo is upstream of ~30 others — a
+# security fix here should surface immediately, not a week later. Without
+# this file, anthropics/claude-code-action sat at v1.0.70 for 123 releases
+# and went vulnerable to GHSA-8q5r-mmjf-575q (patched upstream in 1.0.74)
+# with no PR ever opened. See #123.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"


### PR DESCRIPTION
Root-cause fix for #123.

## The gap

This repo SHA-pins every third-party action by policy (`README.md` "Versioning", enforced by the zizmor `unpinned-uses` audit) — but had **no `dependabot.yml`**. Nothing has ever watched those pins for new releases, and there are **zero Dependabot PRs** in this repo's history.

That's why `anthropics/claude-code-action` sat at v1.0.70 for 123 releases and went vulnerable to GHSA-8q5r-mmjf-575q (patched upstream in 1.0.74), inherited fleet-wide by ~30 repos through the floating `v1`/`v3` tags, with no mechanism to notice.

The problem was never that pinning is wrong — it's that pinning was adopted without the updater that makes it viable.

## Why SHA pins + Dependabot rather than floating tags

Floating `@v1` would pick up fixes automatically, but a compromised upstream tag would then execute in ~30 repos holding `id-token: write` and `CLAUDE_CODE_OAUTH_TOKEN`. SHA pins stay immutable against tag-repointing; Dependabot surfaces each release as a reviewable PR. You get the automatic fix *and* the review.

Dependabot also rewrites the trailing version comment along with the SHA, so `# vX.Y.Z` annotations stop drifting — the `ref-version-mismatch` class in #123 item 3.

## What it watches

Three third-party actions currently pinned here:

- `anthropics/claude-code-action`
- `actions/checkout`
- `dependabot/fetch-metadata`

No other ecosystems exist in this repo (no `package.json`, `requirements.txt`, etc.), so `github-actions` is the only entry.

## Fleet consistency

Matches the config already used by `dotfiles`, `claude-config`, `dev-env`, and `dumbify` — same header, `prefix: "chore"`, quoted values, weekly interval.

**One deliberate difference: no `cooldown`.** Consumer repos set `default-days: 7` to let releases settle. This repo is upstream of ~30 others, so a security fix should surface immediately rather than a week later.

## Note for a separate decision

This repo has no `dependabot-auto-merge.yml` **caller stub** — only the reusable definition. So these PRs will open and await manual merge rather than auto-merging.

That seems correct for the repo defining the fleet's workflows (a human should see each bump before it propagates), and both local reviewers agreed. Flagging it explicitly rather than silently deciding it.

Also worth knowing: `anthropics/` is not in the auto-merge workflow's always-trusted namespace list (`dependabot/`, `actions/`, plus caller orgs), so even with a caller stub, `claude-code-action` **major** bumps would stop for human review while patch/minor flowed through.

Refs #123

https://claude.ai/code/session_01SimcNSM4P5hpb1dQVejqcF