### PR TITLE
fix(ci): correct actions/checkout version comments after v7 bump

### DIFF
--- a/.github/workflows/claude-assistant.yml
+++ b/.github/workflows/claude-assistant.yml
@@ -38,7 +38,7 @@ jobs:
       id-token: write # required by claude-code-action for internal authentication
     steps:
       - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude-blocking-review.yml
+++ b/.github/workflows/claude-blocking-review.yml
@@ -129,7 +129,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 1
 


### PR DESCRIPTION
Fixes an actively-wrong version annotation introduced by #130, and closes item 3 of #123.

## What happened

#130 bumped `actions/checkout` from v4.3.1 → **v7.0.1** in three workflows. Dependabot rewrote the trailing comment in `self-review.yml` but left `# v4` in place in the two reusable workflows:

```yaml
# before this PR, on main:
uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4        ← claims v4
uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1    ← self-review.yml, correct
```

That's worse than the stale comments described in #123 item 3. Those understated the same major version (`# v4` for v4.3.1); this one claimed **v4 while pointing at v7**.

Verified:

```console
$ gh api repos/actions/checkout/tags --paginate \
    --jq '.[]|select(.commit.sha=="3d3c42e5aac5ba805825da76410c181273ba90b1")|.name'
v7.0.1
v7

$ # the prior pin, for reference
$ ... select(.commit.sha=="34e114876b0b11c390a56381ad16ebd13914f8d5") ...
v4.3.1
```

## The fix

Both comments corrected to `# v7.0.1`. All three checkout pins now agree, and **zizmor reports zero `ref-version-mismatch` findings** (was 2).

## Why item 3 was never cosmetic

`self-review.yml` got the correct comment because it already read `# v4.3.1` — precise enough for Dependabot to parse and rewrite. The two reusable workflows read `# v4`, which Dependabot skipped.

So the vague comments weren't just untidy: they were the reason the annotation silently went wrong on the next major bump. **Precise version comments are a precondition for the updater added in #128 to maintain them at all.** I described that updater in #128 as keeping annotations accurate; that's only true where the comment is already precise, and this PR makes that true here.

## Scope note

The floating `v1`/`v3` tags still point at `9422220` and do **not** include the checkout v7 bump. So neither #130 nor this PR reaches the ~30 consumer repos yet — deliberate, since a 3-major-version jump in `actions/checkout` has only been exercised by this repo's own CI.

Whether to move the fleet to checkout v7 is a separate decision from the GHSA-8q5r-mmjf-575q fix, which is already live on the floating tags.

Refs #123

https://claude.ai/code/session_01SimcNSM4P5hpb1dQVejqcF