### PR TITLE
fix(security): close template-injection, drop persisted checkout creds

### DIFF
--- a/.github/workflows/claude-assistant.yml
+++ b/.github/workflows/claude-assistant.yml
@@ -41,6 +41,12 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
+          # See the matching note in claude-blocking-review.yml: nothing here
+          # consumes the persisted credential. claude-code-action takes its
+          # own github_token input and runs no git push/commit, so dropping
+          # it removes exposure without removing capability (zizmor:
+          # artipacked).
+          persist-credentials: false
 
       - name: Verify CLAUDE_CODE_OAUTH_TOKEN is configured
         env:

--- a/.github/workflows/claude-blocking-review.yml
+++ b/.github/workflows/claude-blocking-review.yml
@@ -132,6 +132,13 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 1
+          # Nothing in this job reads the credential checkout would otherwise
+          # persist into .git/config: every gh call sets GH_TOKEN explicitly
+          # from github.token, there are no git push/fetch/pull operations,
+          # and claude-code-action authenticates via its own github_token
+          # input. Leaving it persisted only widens the blast radius of any
+          # step that reads the workspace (zizmor: artipacked).
+          persist-credentials: false
 
       - name: Verify caller permissions
         env:
@@ -268,8 +275,17 @@ jobs:
       - name: Check for Dependabot PR
         id: dependabot-check
         if: steps.doc-check.outputs.skip != 'true'
+        env:
+          # Passed via env rather than interpolated directly into the run
+          # block: `${{ }}` expansion splices the value into the shell source
+          # before bash parses it, so a hostile value would be executed rather
+          # than compared. github.actor is constrained to real account names
+          # (so not freely attacker-authored the way a PR title or branch name
+          # is), but an attacker does choose which account opens a fork PR —
+          # treat it as untrusted input and keep it out of shell source.
+          ACTOR: ${{ github.actor }}
         run: |
-          if [ "${{ github.actor }}" = "dependabot[bot]" ]; then
+          if [ "$ACTOR" = "dependabot[bot]" ]; then
             echo "::notice::Dependabot PR — skipping AI review (version bumps are low-risk)."
             echo "skip=true" >> "$GITHUB_OUTPUT"
             echo "skip_reason=Dependabot version bump" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Resolves items **2** and **4** of #123. With this, `zizmor` reports **no findings** on the two reusable workflows — the first time today a workflow commit here hasn't needed `SKIP=zizmor`.

## Item 2 — template-injection (High)

`claude-blocking-review.yml` interpolated `${{ github.actor }}` straight into a `run:` block. `${{ }}` expansion splices the value into the shell *source* before bash parses it, so a hostile value would be executed rather than compared.

```yaml
# before
run: |
  if [ "${{ github.actor }}" = "dependabot[bot]" ]; then

# after
env:
  ACTOR: ${{ github.actor }}
run: |
  if [ "$ACTOR" = "dependabot[bot]" ]; then
```

Verified the branch logic is unchanged and that a command-substitution payload is now inert:

```console
$ ACTOR='$(touch /tmp/pwned)' bash -c 'if [ "$ACTOR" = "dependabot[bot]" ]; then ...'
  actor=[$(touch /tmp/pwned)] -> skip=false
$ ls /tmp/pwned
  no file — safe
```

## Item 4 — artipacked: the premise in #123 was wrong

#123 anticipated this would be a documented suppression, because "both jobs legitimately need the token for subsequent `gh` calls."

That isn't true. I checked all three consumers of a persisted credential:

- **Every `gh` call** in both workflows sets `GH_TOKEN: ${{ github.token }}` explicitly (`:138`, `:172`, `:295`, `:353`) — none relies on `.git/config`.
- **No `git push`/`fetch`/`pull`/`clone`** anywhere in either workflow.
- **`claude-code-action`** takes its own `github_token` input and runs zero `git push`/`git commit` (checked against the pinned v1.0.193 `action.yml`).

Nothing consumes the credential that `actions/checkout` persists. So this sets `persist-credentials: false` rather than suppressing the finding — removing real exposure instead of documenting a reason to keep it.

Writing the suppression would have baked an inaccurate claim into the codebase, which is worse than the finding it silenced.

## Result

`zizmor` on the two reusable workflows: **4 medium + 1 high → clean.**

```
No findings to report. Good job! (7 suppressed)
```

Repo-wide, one High remains — `claude.yml:22` pinning `claude-assistant.yml@v3` by tag. That's the **documented policy** (`README.md:207`: reusable workflows use semver tags, not SHA pins), i.e. item 5 of #123 (`ship a zizmor.yml`), deliberately out of scope here.

## Note on the inline comment

The adversarial reviewer caught that my first draft called `github.actor` "not attacker-chosen." Imprecise: an attacker does choose which account opens a fork PR. Reworded to say the value is constrained to real account names but should still be treated as untrusted — the code was always right, but the comment could have misled someone copying the pattern.

## Scope

Floating `v1`/`v3` still point at `9422220`; this doesn't reach consumers until a tag repoint. Note that repoint would also carry the unreleased `actions/checkout` v4.3.1 → v7.0.1 bump (#130), which still wants its own decision.

Refs #123

https://claude.ai/code/session_01SimcNSM4P5hpb1dQVejqcF