### PR TITLE
fix(scripts): guard rm -rf, stop bypassing hooks, float the embedded ref

### DIFF
--- a/nightowl-restore-blocking-review.sh
+++ b/nightowl-restore-blocking-review.sh
@@ -32,7 +32,13 @@ permissions:
 
 jobs:
   claude-review:
-    uses: smartwatermelon/github-workflows/.github/workflows/claude-blocking-review.yml@v3.0.0
+    # Floating @v3, not an exact @v3.x.y pin. Exact pins are immutable, so a
+    # caller pinned to one silently opts out of every security fix published
+    # afterwards — that is how ~19 smartwatermelon repos kept resolving to a
+    # claude-code-action vulnerable to GHSA-8q5r-mmjf-575q. This template
+    # previously carried @v3.0.0 and would have deployed that same defect
+    # across every NightOwl repo it touched.
+    uses: smartwatermelon/github-workflows/.github/workflows/claude-blocking-review.yml@v3
     with:
       pr_number: ${{ github.event.pull_request.number }}
     secrets:
@@ -115,14 +121,39 @@ restore_repo() {
   fi
 
   # Fresh path: clone, branch, write file, commit, push, PR, auto-merge
+  #
+  # Guard before the rm: `set -u` catches an *unset* variable but not an
+  # *empty* one, and ALL_REPOS is built from command output (see the
+  # empty-element check at the top). An empty $repo would make clone
+  # "${WORK_DIR}/" and this rm would wipe the whole work dir instead of one
+  # clone. Refuse rather than delete a path we did not intend to build.
+  if [[ -z "${WORK_DIR:-}" || -z "${repo:-}" ]]; then
+    echo "  FATAL: refusing to remove clone dir — WORK_DIR or repo is empty" >&2
+    return 1
+  fi
+  # Reject any repo name that is not a single plain path segment. A textual
+  # "starts with $WORK_DIR/" check is not enough: "../escape" satisfies it
+  # while resolving outside the work dir entirely. GitHub repo names are
+  # limited to [A-Za-z0-9._-], so anything else is either a bug upstream or
+  # an attempt to traverse.
+  if [[ ! "$repo" =~ ^[A-Za-z0-9._-]+$ || "$repo" == "." || "$repo" == ".." ]]; then
+    echo "  FATAL: refusing to remove clone dir — unsafe repo name '${repo}'" >&2
+    return 1
+  fi
   clone="${WORK_DIR}/${repo}"
-  rm -rf "$clone"
+  rm -rf -- "$clone"
   git clone --depth=1 "git@github.com:${ORG}/${repo}.git" "$clone" --quiet
   git -C "$clone" checkout -b "$BRANCH" --quiet
   mkdir -p "${clone}/.github/workflows"
   printf '%s\n' "$WORKFLOW_CONTENT" >"${clone}/.github/workflows/claude-blocking-review.yml"
   git -C "$clone" add .github/workflows/claude-blocking-review.yml
-  git -C "$clone" commit --no-verify --quiet -m "chore: restore claude-blocking-review caller
+  # Commit normally — hooks are NOT bypassed here. This previously passed a
+  # verify-skipping flag, which the repo's own policy forbids and which
+  # silently disabled any commit hooks the target repo installs. The content
+  # is a fixed template, so there is nothing a hook would legitimately need
+  # to reject; if one does reject it, that is signal worth seeing rather
+  # than suppressing.
+  git -C "$clone" commit --quiet -m "chore: restore claude-blocking-review caller
 
 Restoring per-repo blocking-review caller after the org ruleset rollout was
 paused. Until the ruleset's workflow firing behavior is validated, the per-repo


### PR DESCRIPTION
Three defects in `nightowl-restore-blocking-review.sh`, a committed operational artifact from the paused 2026-04-30 ruleset rollout.

**It is currently dormant** — no running process, `/tmp/restore-blocking-review` does not exist, and nothing invokes it (the only reference is a plan doc describing it as an artifact). But it loops over a dynamically-discovered repo list and deletes paths, so these are worth closing before any reuse.

## 1. Unguarded `rm -rf` on a constructed path

```bash
clone="${WORK_DIR}/${repo}"
rm -rf "$clone"
```

`set -euo pipefail` gives partial cover — `nounset` aborts on an *unset* variable — but **not on an empty one**. `ALL_REPOS` is built from `gh repo list` output, and the script already carries an empty-element check at line 62, acknowledging that case is reachable. An empty `$repo` yields `clone="${WORK_DIR}/"`, and the `rm -rf` wipes the entire work dir instead of one clone.

The fix rejects empty values **and** any repo name that isn't a single plain path segment. A textual "starts with `$WORK_DIR/`" check is not sufficient — my first attempt used one, and `../escape` passed it while resolving outside the work dir entirely.

Verified against 8 inputs:

| input | result |
|---|---|
| `""` | REFUSED (empty) |
| `..`, `.`, `../escape` | REFUSED (unsafe name) |
| `a/b`, `sub dir` | REFUSED (unsafe name) |
| `realrepo`, `ok-name_1.2` | allowed |

Sentinel file in the work dir survived every refused case.

## 2. Commits bypassed hooks

The commit passed a verify-skipping flag — forbidden by this repo's own policy, and it silently disabled whatever commit hooks the *target* repo installs. Removed.

The content is a fixed template, so there's nothing a hook would legitimately need to reject. If one does, that's signal worth seeing rather than suppressing.

## 3. The embedded template pinned `@v3.0.0`

```yaml
uses: smartwatermelon/github-workflows/.github/workflows/claude-blocking-review.yml@v3.0.0
```

Exact pins are immutable — precisely how ~19 `smartwatermelon` repos kept resolving to a `claude-code-action` vulnerable to GHSA-8q5r-mmjf-575q (#126). This script would have deployed that same defect across **every NightOwl repo it touched**, and `@v3.0.0` is older still than the `@v3.1.0` that caused the original problem.

Now floats `@v3`, matching the fleet standard set in #138.

## Verification

- `shellcheck -S info` clean, no `# shellcheck disable` directives added
- `bash -n` syntax OK
- Guard behavior tested directly (table above)

Refs #126

https://claude.ai/code/session_01SimcNSM4P5hpb1dQVejqcF