### PR TITLE
feat(zizmor): ship a config so consumers stop bypassing the linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,34 @@ $ gh api "repos/smartwatermelon/github-workflows/contents/.github/workflows/clau
     --jq '.content' | base64 -d | grep -oE 'claude-code-action@[a-f0-9]{8}'
 ```
 
+### `zizmor.yml` — required alongside the caller stubs
+
+If you run `zizmor` (e.g. as a pre-commit hook), copy [`zizmor.yml`](./zizmor.yml)
+from this repo to your repo root when you adopt the caller stubs.
+
+Without it, zizmor's blanket hash-pin policy reports roughly **9 high findings
+against a byte-identical standard stub** — the tag refs and the required
+`permissions:` blocks — and the only workaround is `SKIP=zizmor` on every
+commit that touches a workflow.
+
+**That workaround is the hazard the config exists to remove.** Routinely
+skipping the security linter is what let `anthropics/claude-code-action` sit at
+v1.0.70 for 123 releases while carrying GHSA-8q5r-mmjf-575q. A linter people
+bypass by habit protects nothing.
+
+The config encodes two documented policy decisions and nothing else:
+
+| Rule | Treatment | Why |
+| --- | --- | --- |
+| `unpinned-uses` | `ref-pin` for `smartwatermelon/github-workflows/*`, strict `hash-pin` for everything else | Reflects the two-class policy above. Third-party findings stay visible. |
+| `excessive-permissions` | ignored for the three standard caller filenames | Those blocks are required by the reusable workflows; removing them causes `startup_failure`, not a narrower blast radius. |
+
+It is deliberately **not** a blanket mute. On a representative consumer it takes
+findings from 9 high to 2 — and the 2 that survive are genuine third-party
+actions pinned to floating majors in that repo's own workflows, which is a real
+gap worth fixing rather than policy. A repo's own workflows are still audited
+normally.
+
 #### The `v1` line is deprecated
 
 **Tags in this repo are repo-wide, not per-file.** A git tag labels a commit,

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -1,0 +1,87 @@
+# zizmor configuration for repos consuming the smartwatermelon workflow set.
+#
+# Copy this to the root of any repo that uses the caller stubs from this
+# repo's README, alongside your pre-commit hook. Without it, zizmor's blanket
+# hash-pin policy reports ~9 high findings against a byte-identical standard
+# caller stub, and the only workaround is `SKIP=zizmor` on every commit.
+#
+# That workaround is the actual hazard this file exists to remove. Routinely
+# skipping the security linter is what let anthropics/claude-code-action sit
+# at v1.0.70 for 123 releases while carrying GHSA-8q5r-mmjf-575q (see #123).
+# A linter people bypass by habit protects nothing.
+#
+# Every entry below is a *documented policy decision*, not a convenience
+# mute. Each one is justified against the code. Findings that reflect a real
+# gap are deliberately left visible — see the note on third-party actions.
+
+rules:
+  # ---------------------------------------------------------------------
+  # unpinned-uses
+  # ---------------------------------------------------------------------
+  # zizmor's default is a blanket hash-pin requirement: every `uses:` must
+  # name a commit SHA. That is correct for third-party actions and wrong for
+  # first-party reusable workflows, and this repo deliberately treats the two
+  # classes differently:
+  #
+  #   Third-party actions      -> SHA-pin, plus dependabot.yml to keep the
+  #   (actions/checkout, ...)     pins current. We do not control upstream, so
+  #                               a repointed tag would run arbitrary code on
+  #                               the next trigger.
+  #
+  #   First-party reusable     -> floating tag (@v3). We control this repo,
+  #   workflows (this repo)       its branch protection, and who moves the
+  #                               tag. Floating refs are what make coordinated
+  #                               fleet remediation possible at all.
+  #
+  # The second rule is not a relaxation — it is load-bearing. When
+  # GHSA-8q5r-mmjf-575q was patched here, the fix reached consumers by
+  # repointing one tag. The ~19 repos that had pinned an exact @v3.1.0
+  # silently received nothing, because immutable tags cannot carry a fix
+  # published after they were cut. Hash-pinning a first-party ref has the
+  # same effect, permanently.
+  #
+  # `ref-pin` still requires *a* ref — `@main` or a bare repo reference is
+  # rejected. It only lifts the hash requirement.
+  unpinned-uses:
+    config:
+      policies:
+        # First-party: tag refs are the convention (see README "Versioning").
+        smartwatermelon/github-workflows/*: ref-pin
+        # Everything else keeps the strict default. This line matters: it is
+        # what keeps genuine third-party findings visible. A blanket ignore
+        # here would also hide, e.g., `actions/checkout@v7` in a repo's own
+        # workflows — which is a real gap worth fixing, not policy.
+        "*": hash-pin
+
+  # ---------------------------------------------------------------------
+  # excessive-permissions
+  # ---------------------------------------------------------------------
+  # The caller stubs declare workflow-level permissions because the reusable
+  # workflows require them. They are not aspirational or copy-pasted:
+  #
+  #   contents: read        - checkout and diff reading
+  #   pull-requests: write  - posting and minimizing review comments
+  #   issues: write         - the inline-comment API path
+  #   id-token: write       - OIDC exchange for the app token
+  #
+  # `dependabot-auto-merge.yml` is in the list for the same reason but needs
+  # a different pair — `contents: write` to merge and `pull-requests: write`
+  # to approve. Both are inherent to what that workflow does; a read-only
+  # auto-merger is a contradiction. Note it deliberately runs with no
+  # `actions/checkout` (enforced by this repo's `guard-no-checkout` job), so
+  # the write scopes never combine with executing PR-controlled code.
+  #
+  # Removing any of them does not narrow the blast radius; it produces a
+  # `startup_failure` before the job runs. GitHub also does not let a caller
+  # grant a called workflow more than the called workflow declares for
+  # itself, so the effective ceiling is set in the reusable workflow, not
+  # here.
+  #
+  # Scoped to the three standard caller filenames only. A repo's own
+  # workflows are still audited normally — if `validate.yml` or `release.yml`
+  # asks for more than it needs, that finding still fires.
+  excessive-permissions:
+    ignore:
+      - claude-blocking-review.yml
+      - claude.yml
+      - dependabot-auto-merge.yml


### PR DESCRIPTION
Closes the last item of #126 (carried over from #123 item 5).

## The problem

Every repo adopting the standard caller stubs inherits a pre-commit hook that reports **~9 high findings against a byte-identical stub** — the tag refs and the required `permissions:` blocks. The only workaround is `SKIP=zizmor` on every workflow commit.

**That workaround is the hazard.** Routinely skipping the security linter is what let `anthropics/claude-code-action` sit at v1.0.70 for 123 releases while carrying GHSA-8q5r-mmjf-575q. A linter people bypass by habit protects nothing.

This isn't theoretical: three separate agents hit that wall today during the #126 work, each needing `SKIP=zizmor`, each having to verify by hand that the blocking findings were pre-existing. That manual check is exactly what stops happening once skipping is routine.

## What it encodes

Two entries, both documented policy — not convenience mutes:

| Rule | Treatment | Why |
| --- | --- | --- |
| `unpinned-uses` | `ref-pin` for `smartwatermelon/github-workflows/*`, strict `hash-pin` for everything else | The two-class policy: SHA-pin third-party actions we don't control; floating tag for first-party workflows we do |
| `excessive-permissions` | ignored for the 3 standard caller filenames | Those blocks are required by the reusable workflows — removing them yields `startup_failure`, not a narrower blast radius |

The `unpinned-uses` half is load-bearing, not a relaxation. Hash-pinning a first-party ref permanently opts a repo out of coordinated remediation — precisely how ~19 repos missed the GHSA fix while looking conformant.

## Verified not to be a blanket mute

This is the part that matters for a file whose whole job is suppressing findings:

- **Representative consumer (`dumbify`): 9 high → 2 high.** The 2 survivors are genuine third-party actions (`actions/checkout@v7`, `actions/setup-python@v7`) pinned to floating majors in that repo's *own* `validate.yml`. Real gap, left visible.
- **Negative test** against a deliberately bad workflow: still reports unpinned third-party actions and `artipacked`.
- **This repo:** clean both before and after, so the config adds no suppression here.

The `"*": hash-pin` line is what preserves the third-party findings. A blanket `unpinned-uses` ignore would have hidden them too.

## Also

Documents adoption in the README, including that the config must be copied alongside the caller stubs.

Per review feedback, the inline comment now also justifies `dependabot-auto-merge.yml`'s presence in the ignore list — it needs `contents: write` (merge) and `pull-requests: write` (approve), and runs with no `actions/checkout` (enforced by `guard-no-checkout`), so the write scopes never combine with executing PR-controlled code.

Refs #126

https://claude.ai/code/session_01SimcNSM4P5hpb1dQVejqcF