### PR TITLE
feat(claude-assistant): add allowed_tools and model inputs

### DIFF
--- a/.github/workflows/claude-assistant.yml
+++ b/.github/workflows/claude-assistant.yml
@@ -20,9 +20,57 @@ name: Claude Code Assistant
 #       uses: smartwatermelon/github-workflows/.github/workflows/claude-assistant.yml@v1
 #       secrets:
 #         claude_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+#
+# Optional per-repo customization (both inputs default to empty, which
+# reproduces the action's own defaults exactly):
+#
+#       with:
+#         # Grant Claude an explicit tool list. Enumerate only the read-only
+#         # git/gh subcommands the repo actually needs, so destructive
+#         # variants (git push/reset/checkout/clean, gh pr merge) are never
+#         # granted by this repo. See the additive-semantics note below.
+#         allowed_tools: 'Read,Edit,Write,Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git rev-parse:*),Bash(git ls-files:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr list:*),Bash(gh pr comment:*)'
+#         model: 'claude-opus-4-7'
+#
+# Deliberately NOT a free-form `claude_args` passthrough: an opaque arg blob
+# lets a caller pass flags that *widen* permissions, which is the opposite of
+# what an allowlist is for. Discrete inputs keep the surface auditable from
+# the caller stub. See #141.
+#
+# IMPORTANT — `allowed_tools` is ADDITIVE, not a replacement. Verified against
+# claude-code-action v1.0.193: in tag mode (which is what this workflow runs)
+# src/modes/tag/index.ts unconditionally emits its own
+# `--allowedTools "<tag mode tools>"` and then APPENDS the caller's
+# claude_args after it. base-action/src/parse-sdk-options.ts then treats
+# `--allowedTools` and `--allowed-tools` as aliases and UNIONS every
+# occurrence (`new Set([...])`), rather than letting the last one win.
+#
+# So this input can only ever GRANT tools on top of the action's tag-mode
+# baseline — it cannot revoke anything the action grants itself. Use it to
+# add the specific tools a repo needs (and to pin `model`); do not read it as
+# a hard sandbox. Genuinely revoking a tool needs `--disallowed-tools`, which
+# this workflow does not yet expose; if you need that, open an issue rather
+# than assuming an allowlist here has removed something.
 
 on:
   workflow_call:
+    inputs:
+      allowed_tools:
+        description: |
+          Comma-separated tool allowlist passed to claude-code-action as
+          --allowed-tools. Empty (default) = the action's default tool policy.
+          NOTE: this UNIONS with the action's own tag-mode tool set, it does
+          not replace it — see the note in the header comment.
+        type: string
+        required: false
+        default: ''
+      model:
+        description: |
+          Claude model ID passed as --model. Empty (default) = the action's
+          default model.
+        type: string
+        required: false
+        default: ''
     secrets:
       claude_oauth_token:
         description: 'Claude Code OAuth token (CLAUDE_CODE_OAUTH_TOKEN secret)'
@@ -47,6 +95,94 @@ jobs:
           # it removes exposure without removing capability (zizmor:
           # artipacked).
           persist-credentials: false
+
+      - name: Validate inputs and build claude_args
+        id: args
+        env:
+          ALLOWED_TOOLS: ${{ inputs.allowed_tools }}
+          MODEL: ${{ inputs.model }}
+        run: |
+          # Both inputs are consumed via env: (never interpolated directly
+          # into this run: block) so a caller cannot inject shell through
+          # them. The validation below is defence-in-depth on top of that:
+          # the assembled string is handed to claude-code-action, which
+          # word-splits it as a command line, so any value that could
+          # terminate the quoted --allowed-tools argument is rejected
+          # outright rather than sanitized.
+
+          # Validate model: empty (action default) or alphanumeric/dots/
+          # hyphens. Same pattern and error style as claude-blocking-review.yml.
+          # NOTE on grep: `grep -qE '^…$'` matches PER LINE, so a multi-line
+          # value could smuggle a bad line past an otherwise-anchored pattern.
+          # Both inputs are therefore newline-checked before the charset check,
+          # using parameter expansion against a literal newline (no subshell).
+          NL=$'\n'
+          if [ -n "$MODEL" ]; then
+            if [ "${MODEL%%"$NL"*}" != "$MODEL" ]; then
+              echo "::error::model must not contain newlines."
+              exit 1
+            fi
+            if ! printf '%s' "$MODEL" | grep -qE '^[a-zA-Z0-9._-]+$'; then
+              echo "::error::Invalid model name. Must be empty (action default) or match [a-zA-Z0-9._-]+"
+              exit 1
+            fi
+          fi
+
+          # Validate allowed_tools. Reject quotes, backticks, $, ;, &, |,
+          # backslashes, and newlines — none are legitimate in a tool
+          # allowlist, and all are quote-breakout or command-substitution
+          # vectors.
+          #
+          # The permitted class is deliberately the minimum that real tool
+          # specs need, and nothing more:
+          #   letters/digits/_  tool and MCP names
+          #                     (mcp__github_inline_comment__create_inline_comment)
+          #   ,                 separator between specs
+          #   ( ) : *           Bash matcher syntax — Bash(git status:*)
+          #   space             multi-word subcommands — Bash(gh pr view:*)
+          #   . / -             paths and flags inside a matcher
+          # `+` and `@` are excluded: no tool spec format uses them.
+          #
+          # Note the space: it means values legitimately contain spaces, which
+          # is exactly why the assembled --allowed-tools argument below must
+          # stay double-quoted. Verified against claude-code-action v1.0.193:
+          # src/modes/agent/parse-tools.ts tokenizes claude_args with
+          # shell-quote (parseShellArgs), so the double quotes are honored as
+          # real shell quoting and a spec like Bash(gh pr view:*) survives
+          # intact. claude-blocking-review.yml quotes its literal allowlist
+          # for the same reason, and the action itself emits
+          # --allowedTools "..." the same way.
+          if [ -n "$ALLOWED_TOOLS" ]; then
+            # Newlines first: a multi-line value would both break the
+            # generated command line and corrupt the $GITHUB_OUTPUT write
+            # below (a bare `key=value` output entry is single-line only).
+            if [ "${ALLOWED_TOOLS%%"$NL"*}" != "$ALLOWED_TOOLS" ]; then
+              echo "::error::allowed_tools must not contain newlines."
+              exit 1
+            fi
+            if ! printf '%s' "$ALLOWED_TOOLS" | grep -qE '^[a-zA-Z0-9_,:*()./ -]+$'; then
+              echo "::error::allowed_tools contains disallowed characters."
+              echo "::error::Allowed: letters, digits, and _ , : * ( ) . / space -"
+              echo "::error::Rejected (shell-injection vectors): quotes, backticks, \$, ;, &, |, backslashes, newlines."
+              echo "::error::Example: 'Read,Bash(git status:*),Bash(gh pr view:*)'"
+              exit 1
+            fi
+          fi
+
+          # Assemble claude_args. When BOTH inputs are empty the output is the
+          # empty string, and claude-code-action's claude_args default is also
+          # the empty string — so the default path is unchanged from before
+          # these inputs existed.
+          CLAUDE_ARGS=""
+          if [ -n "$MODEL" ]; then
+            CLAUDE_ARGS="--model $MODEL"
+          fi
+          if [ -n "$ALLOWED_TOOLS" ]; then
+            CLAUDE_ARGS="${CLAUDE_ARGS:+$CLAUDE_ARGS }--allowed-tools \"$ALLOWED_TOOLS\""
+          fi
+
+          echo "claude_args=$CLAUDE_ARGS" >> "$GITHUB_OUTPUT"
+          echo "claude_args: ${CLAUDE_ARGS:-(none - action defaults)}"
 
       - name: Verify CLAUDE_CODE_OAUTH_TOKEN is configured
         env:
@@ -101,5 +237,8 @@ jobs:
           # performs the instructions in the comment that tagged it.
           # prompt: 'Update the pull request description to include a summary of changes.'
 
-          # Optional: restrict which tools Claude can use
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
+          # Built from the `allowed_tools` / `model` workflow_call inputs by
+          # the "Validate inputs and build claude_args" step above. Empty when
+          # neither input is set, which is exactly what the action receives by
+          # default — see #141.
+          claude_args: ${{ steps.args.outputs.claude_args }}

--- a/README.md
+++ b/README.md
@@ -414,6 +414,68 @@ jobs:
 
 Add `CLAUDE_CODE_OAUTH_TOKEN` to your repository or organization secrets.
 
+### Inputs
+
+| Input | Type | Default | Description |
+| ----- | ---- | ------- | ----------- |
+| `allowed_tools` | string | `''` | Tool allowlist passed as `--allowed-tools`. Empty = action default policy. |
+| `model` | string | `''` | Model ID passed as `--model`. Empty = action default model. |
+
+Both are optional. With both empty the workflow passes no `claude_args` at
+all, so behavior is identical to a caller that sets neither.
+
+#### Restricting tools (recommended)
+
+The assistant runs with `id-token: write` and a `CLAUDE_CODE_OAUTH_TOKEN`. If
+your repo has an opinion about what Claude should be able to run, encode it as
+an allowlist rather than relying on whatever the action's defaults happen to
+be.
+
+The example below keeps `Edit`/`Write` — the assistant is expected to change
+files in its checkout, so those are in scope — but grants only **read-only
+`git`/`gh` subcommands**, so destructive variants (`git push`, `git reset`,
+`git checkout`, `git clean`, `gh pr merge`) are never granted *by this repo*.
+Read the additive-semantics note below before treating that as a guarantee:
+
+```yaml
+    uses: smartwatermelon/github-workflows/.github/workflows/claude-assistant.yml@v3.1.2
+    with:
+      allowed_tools: 'Read,Edit,Write,Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git rev-parse:*),Bash(git ls-files:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr list:*),Bash(gh pr comment:*),mcp__github_inline_comment__create_inline_comment'
+      model: claude-opus-4-7
+    secrets:
+      claude_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+```
+
+`mcp__github_inline_comment__create_inline_comment` in the example only works
+if that MCP server is available to the run; drop it if you aren't using it.
+
+#### What `allowed_tools` does and does not do
+
+**It is additive.** Verified against `claude-code-action` v1.0.193: in tag mode
+(what this workflow runs) the action emits its own
+`--allowedTools "<tag mode tools>"` and appends your `claude_args` after it,
+and its parser treats `--allowedTools`/`--allowed-tools` as aliases and
+**unions** every occurrence rather than letting the last win.
+
+So `allowed_tools` can only **grant** tools on top of the action's baseline —
+it cannot revoke anything the action grants itself. It restores the ability to
+express a per-repo tool policy without inlining the action, and it keeps that
+policy visible in the caller stub, but do not read it as a hard sandbox.
+Revoking a tool requires `--disallowed-tools`, which this workflow does not yet
+expose; open an issue if you need it.
+
+Both inputs are validated before use. `model` must match
+`[a-zA-Z0-9._-]+`; `allowed_tools` is passed via `env:` (never interpolated
+into a `run:` line) and rejects quotes, backticks, `$`, `;`, `&`, `|`,
+backslashes, and newlines, so a caller cannot break out of the generated
+command line. Spaces are permitted because tool specs need them
+(`Bash(gh pr view:*)`), which is why the generated argument stays quoted.
+
+There is deliberately **no free-form `claude_args` passthrough**: an opaque
+arg blob would let a caller pass flags that *widen* permissions, which is the
+opposite of what an allowlist is for. Discrete inputs keep the surface
+auditable from the caller stub.
+
 ### Security note
 
 The `author_association` guard in the `if:` condition **must stay in the caller**


### PR DESCRIPTION
Closes #141.

## The problem

`claude-assistant.yml` accepted **no `workflow_call` inputs at all** — only the `claude_oauth_token` secret. So any repo needing per-repo customization had exactly one option: inline `anthropics/claude-code-action` itself, which drops it out of the fleet update path entirely. That is the defect that left `claude-code-workflows-agents` 62 releases stale on a security-sensitive action and missing a remediation for months (#126).

Migrating that repo onto the standard stub forced dropping a deliberate tool allowlist that named only read-only `git`/`gh` subcommands. Since then the assistant has run on the action's default tool policy while holding `id-token: write` and a `CLAUDE_CODE_OAUTH_TOKEN`.

## What this adds

Two discrete, optional `workflow_call` inputs:

| Input | Default | Effect |
|-------|---------|--------|
| `allowed_tools` | `''` | Appended as `--allowed-tools "<value>"` |
| `model` | `''` | Appended as `--model <value>` |

Deliberately **not** a free-form `claude_args` passthrough: an opaque arg blob lets a caller pass flags that *widen* permissions, which is the opposite of what an allowlist is for. Discrete inputs keep the surface auditable from the caller stub.

## Semantics — verified, not assumed

I read `claude-code-action` v1.0.193 rather than guessing, and the result changed how this is documented:

- `src/modes/tag/index.ts` (tag mode is what this workflow runs) emits its **own** `--allowedTools "<tag mode tools>"` and then **appends** the caller's `claude_args` after it.
- `base-action/src/parse-sdk-options.ts` treats `--allowedTools` and `--allowed-tools` as aliases and **unions** every occurrence (`new Set([...])`) rather than letting the last one win.

So `allowed_tools` is **additive**: it grants tools on top of the action's baseline and **cannot revoke** what the action grants itself. Rather than overstate the guarantee, the header comment, the input description, and the README all say this plainly, and point at `--disallowed-tools` (not exposed yet) as what real revocation would require.

This still closes the security delta that motivated #141 — a repo can express and audit its tool policy from the caller stub without leaving the fleet — but it does not pretend to be a hard sandbox.

## Injection safety

`allowed_tools` is interpolated into a command line, so it is handled defensively:

- Reaches the shell via `env:`, never via `${{ }}` interpolation into `run:`.
- **Newline check runs first**, because `grep -E` anchors match *per line* — a multi-line value could otherwise smuggle a bad line past an anchored pattern. It would also corrupt the single-line `$GITHUB_OUTPUT` write.
- Charset is the minimum real tool specs need: `[a-zA-Z0-9_,:*()./ -]`. Quotes, backticks, `$`, `;`, `&`, `|`, and backslashes are all rejected. `+` and `@` are excluded because no spec format uses them.
- `model` reuses the reviewer's exact pattern and error style.

15 cases were exercised against the extracted step: every injection attempt (quote-breakout, backtick, `$(...)`, `;`, `|`, `&&`, backslash, newline, single quote, bad model) is rejected; every legitimate value builds correctly.

The generated argument stays **double-quoted** because tool specs legitimately contain spaces (`Bash(gh pr view:*)`). Confirmed end-to-end by running the action's own `parseAllowedTools()` on our emitted string:

```
["Read","Edit","Write","Bash(git status:*)","Bash(gh pr view:*)","mcp__github_inline_comment__create_inline_comment"]
```

Spaces intact — the action tokenizes `claude_args` with `shell-quote`, so the quotes are honored as real quoting.

## Default path unchanged

With both inputs empty, `CLAUDE_ARGS` is the empty string, so the action receives `claude_args: ''` — its own default, and `parseAllowedTools("")` returns `[]`. Behavior is identical to before this PR for every existing caller. No caller needs to change.

## Verification

- `ruby -ryaml -e YAML.unsafe_load_file` — parses clean
- `zizmor` — clean, no regression (3 pre-existing suppressions unchanged)
- `shellcheck -S info` on the extracted step — clean
- Both documented examples (README + workflow header) validate against the charset
- `code-reviewer` + `adversarial-reviewer` pre-commit hooks pass

Docs updated in the workflow header comment and the `claude-assistant` section of `README.md`.

https://claude.ai/code/session_01SimcNSM4P5hpb1dQVejqcF