### PR TITLE
fix(claude-blocking-review): diagnose GitHub API outages as infra, not timeouts

### DIFF
--- a/.github/workflows/claude-blocking-review.yml
+++ b/.github/workflows/claude-blocking-review.yml
@@ -687,6 +687,37 @@ jobs:
               # No verdict found — distinguish a real Claude-side failure
               # (timeout, agent error) from an infrastructure flake.
               if [ "$CLAUDE_OUTCOME" = "failure" ]; then
+                # Before blaming the review, check whether GitHub's API is
+                # simply unavailable. claude-code-action calls
+                # GET /repos/{owner}/{repo}/collaborators/{actor}/permission
+                # with no retry, so a single 503 there kills the run — see #133.
+                # During the 2026-08-17 incident that endpoint failed ~40% of
+                # calls while the status page reported everything operational,
+                # and the message below ("review timed out") sent people to
+                # re-push, which cannot help and burns a CI run each time.
+                #
+                # Probing the same endpoint from here is a heuristic, not
+                # proof: it runs seconds later, so a recovered API produces a
+                # false negative and we fall through to the normal message.
+                # It only ever ADDS a more accurate diagnosis; it never
+                # converts a failure into a pass.
+                INFRA_HINT=""
+                if ! gh api "repos/${GITHUB_REPOSITORY}/collaborators/${GITHUB_ACTOR}/permission" \
+                     --jq '.permission' >/dev/null 2>&1; then
+                  INFRA_HINT="yes"
+                fi
+
+                if [ -n "$INFRA_HINT" ]; then
+                  echo "::error::GitHub API is unavailable — this is NOT a problem with your PR."
+                  echo "::error::claude-code-action's actor permission check failed and it does not retry (see smartwatermelon/github-workflows#133)."
+                  echo "::error::Re-run this job when GitHub recovers: gh run rerun ${GITHUB_RUN_ID} --repo ${GITHUB_REPOSITORY}"
+                  echo "::error::Do NOT re-push — the diff is irrelevant and a new commit will fail the same way."
+                  echo "## Claude Code Review" >> "$GITHUB_STEP_SUMMARY"
+                  echo "**Verdict:** INCOMPLETE — GitHub API unavailable, not a PR problem." >> "$GITHUB_STEP_SUMMARY"
+                  echo "Re-run the job (not a re-push) once GitHub recovers. See [#133](https://github.com/smartwatermelon/github-workflows/issues/133)." >> "$GITHUB_STEP_SUMMARY"
+                  exit 1
+                fi
+
                 echo "::error::Review did not complete (likely timed out or failed to render verdict). No verdict rendered."
                 echo "::error::Re-push to retry, or add [skip-claude-review: reason] to the PR body to bypass."
                 echo "## Claude Code Review" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Partially addresses #133.

## The problem

When `claude-code-action` fails because GitHub's API is unavailable, the verdict check said:

> Review did not complete (likely timed out or failed to render verdict).
> Re-push to retry, or add `[skip-claude-review: reason]` to the PR body to bypass.

Both halves are wrong. Nothing timed out, the diff is irrelevant, and **re-pushing fails the same way** for as long as the API is degraded — burning a CI run each time.

## Root cause (upstream)

`claude-code-action` retries the OIDC token exchange 3×, but does **not** retry its actor permission check:

```
Attempt 1 failed: GitHub API is temporarily unavailable...
Attempt 2 of 3...
App token successfully obtained          ← retry worked
Checking permissions for actor: smartwatermelon
GET /repos/.../collaborators/smartwatermelon/permission - 503
##[error]Failed to check permissions for smartwatermelon
```

A single 503 there kills the run. During the 2026-08-17 incident that endpoint failed **~40% of calls** while the GitHub status page reported everything except Copilot as operational. Two runs on `archive-resolver#25` died this way ~2.5h apart on an unrelated one-file shell change — I misdiagnosed it twice before reading the raw log.

## The fix

Before emitting the timeout message, probe the same endpoint the action failed on. If it's also failing here, say so and point at `gh run rerun` instead of a re-push.

**Deliberately still fails closed.** Both paths `exit 1`. A required check must not go green when no review happened — only the classification and remediation advice change.

**The probe is a heuristic, not proof.** It runs seconds after the action, so a recovered API yields a false negative and we fall through to the existing message. It only ever *adds* a more accurate diagnosis; it can never convert a failure into a pass.

## Known edge case

Flagged by the adversarial reviewer and worth stating: if the workflow token lacked collaborator-read access, both the action *and* this probe would fail for that reason, and the message would blame GitHub rather than permissions. Acceptable here — the reusable workflow already validates caller permissions in an earlier step, which would fail first — but noted.

## What this doesn't fix

The upstream retry gap itself. #133 stays open for that: `claude-code-action` should retry the permission check the way it retries the token exchange. Until it does, a GitHub blip still fails the run — it just now says so accurately.

## Verification

- YAML parses; the full 152-line verdict step passes `bash -n`
- `zizmor` clean
- Both branches confirmed to `exit 1`

Refs #133

https://claude.ai/code/session_01SimcNSM4P5hpb1dQVejqcF