### PR TITLE
feat(claude-assistant): add disallowed_tools; fix README version-pin contradictions

### DIFF
--- a/.github/workflows/claude-assistant.yml
+++ b/.github/workflows/claude-assistant.yml
@@ -21,7 +21,7 @@ name: Claude Code Assistant
 #       secrets:
 #         claude_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 #
-# Optional per-repo customization (both inputs default to empty, which
+# Optional per-repo customization (all inputs default to empty, which
 # reproduces the action's own defaults exactly):
 #
 #       with:
@@ -30,6 +30,9 @@ name: Claude Code Assistant
 #         # variants (git push/reset/checkout/clean, gh pr merge) are never
 #         # granted by this repo. See the additive-semantics note below.
 #         allowed_tools: 'Read,Edit,Write,Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git rev-parse:*),Bash(git ls-files:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr list:*),Bash(gh pr comment:*)'
+#         # Revoke tools the action's own baseline would otherwise grant.
+#         # This is the only input that genuinely subtracts — see below.
+#         disallowed_tools: 'Bash(git push:*),Bash(gh pr merge:*),WebFetch'
 #         model: 'claude-opus-4-7'
 #
 # Deliberately NOT a free-form `claude_args` passthrough: an opaque arg blob
@@ -45,12 +48,17 @@ name: Claude Code Assistant
 # `--allowedTools` and `--allowed-tools` as aliases and UNIONS every
 # occurrence (`new Set([...])`), rather than letting the last one win.
 #
-# So this input can only ever GRANT tools on top of the action's tag-mode
-# baseline — it cannot revoke anything the action grants itself. Use it to
-# add the specific tools a repo needs (and to pin `model`); do not read it as
-# a hard sandbox. Genuinely revoking a tool needs `--disallowed-tools`, which
-# this workflow does not yet expose; if you need that, open an issue rather
-# than assuming an allowlist here has removed something.
+# So that input can only ever GRANT tools on top of the action's tag-mode
+# baseline — it cannot revoke anything the action grants itself. Do not read
+# `allowed_tools` as a hard sandbox.
+#
+# To genuinely REVOKE a tool, use `disallowed_tools`, which emits
+# `--disallowed-tools` (a real Claude Code CLI flag; claude_args is passed
+# through to that CLI). A deny entry is evaluated against the resolved tool
+# set, so it subtracts from the action's tag-mode baseline as well as from
+# anything `allowed_tools` added — a spec listed in both is denied. That is
+# the input to reach for when a repo needs an actual restriction rather than
+# an addition (see #146).
 
 on:
   workflow_call:
@@ -61,6 +69,16 @@ on:
           --allowed-tools. Empty (default) = the action's default tool policy.
           NOTE: this UNIONS with the action's own tag-mode tool set, it does
           not replace it — see the note in the header comment.
+        type: string
+        required: false
+        default: ''
+      disallowed_tools:
+        description: |
+          Comma-separated tool denylist passed to claude-code-action as
+          --disallowed-tools. Empty (default) = no denylist.
+          Unlike allowed_tools this genuinely SUBTRACTS: it is evaluated
+          against the resolved tool set, so it can revoke tools the action's
+          own tag-mode baseline grants.
         type: string
         required: false
         default: ''
@@ -100,9 +118,10 @@ jobs:
         id: args
         env:
           ALLOWED_TOOLS: ${{ inputs.allowed_tools }}
+          DISALLOWED_TOOLS: ${{ inputs.disallowed_tools }}
           MODEL: ${{ inputs.model }}
         run: |
-          # Both inputs are consumed via env: (never interpolated directly
+          # All inputs are consumed via env: (never interpolated directly
           # into this run: block) so a caller cannot inject shell through
           # them. The validation below is defence-in-depth on top of that:
           # the assembled string is handed to claude-code-action, which
@@ -114,7 +133,7 @@ jobs:
           # hyphens. Same pattern and error style as claude-blocking-review.yml.
           # NOTE on grep: `grep -qE '^…$'` matches PER LINE, so a multi-line
           # value could smuggle a bad line past an otherwise-anchored pattern.
-          # Both inputs are therefore newline-checked before the charset check,
+          # All inputs are therefore newline-checked before the charset check,
           # using parameter expansion against a literal newline (no subshell).
           NL=$'\n'
           if [ -n "$MODEL" ]; then
@@ -169,16 +188,41 @@ jobs:
             fi
           fi
 
-          # Assemble claude_args. When BOTH inputs are empty the output is the
+          # Validate disallowed_tools. Same threat model, same permitted
+          # class, and the same newline-before-charset ordering as
+          # allowed_tools above — the value lands in the same generated
+          # command line and is quoted for the same reason (specs contain
+          # spaces).
+          if [ -n "$DISALLOWED_TOOLS" ]; then
+            if [ "${DISALLOWED_TOOLS%%"$NL"*}" != "$DISALLOWED_TOOLS" ]; then
+              echo "::error::disallowed_tools must not contain newlines."
+              exit 1
+            fi
+            if ! printf '%s' "$DISALLOWED_TOOLS" | grep -qE '^[a-zA-Z0-9_,:*()./ -]+$'; then
+              echo "::error::disallowed_tools contains disallowed characters."
+              echo "::error::Allowed: letters, digits, and _ , : * ( ) . / space -"
+              echo "::error::Rejected (shell-injection vectors): quotes, backticks, \$, ;, &, |, backslashes, newlines."
+              echo "::error::Example: 'Bash(git push:*),Bash(gh pr merge:*)'"
+              exit 1
+            fi
+          fi
+
+          # Assemble claude_args. When ALL inputs are empty the output is the
           # empty string, and claude-code-action's claude_args default is also
           # the empty string — so the default path is unchanged from before
           # these inputs existed.
           CLAUDE_ARGS=""
           if [ -n "$MODEL" ]; then
-            CLAUDE_ARGS="--model $MODEL"
+            # Quoted for consistency with the tool lists below. The charset
+            # validation already excludes whitespace, so this is defensive
+            # against future charset drift rather than a live fix (see #144).
+            CLAUDE_ARGS="--model \"$MODEL\""
           fi
           if [ -n "$ALLOWED_TOOLS" ]; then
             CLAUDE_ARGS="${CLAUDE_ARGS:+$CLAUDE_ARGS }--allowed-tools \"$ALLOWED_TOOLS\""
+          fi
+          if [ -n "$DISALLOWED_TOOLS" ]; then
+            CLAUDE_ARGS="${CLAUDE_ARGS:+$CLAUDE_ARGS }--disallowed-tools \"$DISALLOWED_TOOLS\""
           fi
 
           echo "claude_args=$CLAUDE_ARGS" >> "$GITHUB_OUTPUT"
@@ -237,8 +281,8 @@ jobs:
           # performs the instructions in the comment that tagged it.
           # prompt: 'Update the pull request description to include a summary of changes.'
 
-          # Built from the `allowed_tools` / `model` workflow_call inputs by
-          # the "Validate inputs and build claude_args" step above. Empty when
-          # neither input is set, which is exactly what the action receives by
-          # default — see #141.
+          # Built from the `allowed_tools` / `disallowed_tools` / `model`
+          # workflow_call inputs by the "Validate inputs and build claude_args"
+          # step above. Empty when none of them is set, which is exactly what
+          # the action receives by default — see #141, #146.
           claude_args: ${{ steps.args.outputs.claude_args }}

--- a/.github/workflows/claude-assistant.yml
+++ b/.github/workflows/claude-assistant.yml
@@ -31,7 +31,7 @@ name: Claude Code Assistant
 #         # granted by this repo. See the additive-semantics note below.
 #         allowed_tools: 'Read,Edit,Write,Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git rev-parse:*),Bash(git ls-files:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr list:*),Bash(gh pr comment:*)'
 #         # Revoke tools the action's own baseline would otherwise grant.
-#         # This is the only input that genuinely subtracts — see below.
+#         # Intended as the revoking input, but see the caveat below.
 #         disallowed_tools: 'Bash(git push:*),Bash(gh pr merge:*),WebFetch'
 #         model: 'claude-opus-4-7'
 #
@@ -55,10 +55,11 @@ name: Claude Code Assistant
 # To genuinely REVOKE a tool, use `disallowed_tools`, which emits
 # `--disallowed-tools` (a real Claude Code CLI flag; claude_args is passed
 # through to that CLI). A deny entry is evaluated against the resolved tool
-# set, so it subtracts from the action's tag-mode baseline as well as from
-# anything `allowed_tools` added — a spec listed in both is denied. That is
-# the input to reach for when a repo needs an actual restriction rather than
-# an addition (see #146).
+# set, and is EXPECTED to subtract from the action's tag-mode baseline as
+# well as from anything `allowed_tools` added. NOTE: that precedence is not
+# verified here — unlike the additive behavior of `allowed_tools`, which was
+# confirmed against v1.0.193 source. Treat it as unproven until a live run
+# confirms it (see #146).
 
 on:
   workflow_call:
@@ -76,9 +77,9 @@ on:
         description: |
           Comma-separated tool denylist passed to claude-code-action as
           --disallowed-tools. Empty (default) = no denylist.
-          Unlike allowed_tools this genuinely SUBTRACTS: it is evaluated
-          against the resolved tool set, so it can revoke tools the action's
-          own tag-mode baseline grants.
+          Intended to SUBTRACT from the resolved tool set, unlike the
+          additive allowed_tools. Precedence against the action's own
+          tag-mode baseline is unverified — confirm with a live run.
         type: string
         required: false
         default: ''

--- a/README.md
+++ b/README.md
@@ -116,16 +116,18 @@ on:
       - 'docs/**'
 
 jobs:
-  # Pin to v3.1.0 or later, not a caller-level `if: github.actor !=
-  # 'dependabot[bot]'` gate. A job-level `if:` that evaluates false means
-  # this job never dispatches, so a required status check on it never
-  # reports — it stays permanently pending on Dependabot PRs under
-  # branch protection that requires the check, blocking auto-merge
-  # entirely. v3.1.0+ instead skips Dependabot PRs from INSIDE the job
-  # (see this file's own "Check for Dependabot PR" step below), so the
-  # job still runs and reports a real PASS. See
-  # smartwatermelon/github-workflows#115/#117 for the incident that
-  # established this; a caller-level gate was tried and reverted.
+  # Do NOT add a caller-level `if: github.actor != 'dependabot[bot]'` gate.
+  # A job-level `if:` that evaluates false means this job never dispatches,
+  # so a required status check on it never reports — it stays permanently
+  # pending on Dependabot PRs under branch protection that requires the
+  # check, blocking auto-merge entirely. The reusable workflow instead
+  # skips Dependabot PRs from INSIDE the job (see its own "Check for
+  # Dependabot PR" step), so the job still runs and reports a real PASS.
+  # `@v3` already resolves to a commit that contains that in-job skip, so
+  # tracking the floating tag is all you need — there is no version floor
+  # to enforce yourself. See smartwatermelon/github-workflows#115/#117 for
+  # the incident that established this; a caller-level gate was tried and
+  # reverted.
   claude-review:
     # Replace YOUR_ORG with smartwatermelon, or your fork's org, before use.
     # Track floating @v3, not an exact @v3.x.y — see "Versioning" below.
@@ -251,8 +253,10 @@ mistake of cutting one and not the other. So:
 
 - **`v1` is frozen** at `v1.2.6` and will not be updated further.
 - **Point every caller at the `v3` line**, including `claude-assistant.yml`
-  callers. `claude-assistant.yml@v3.1.2` is correct and current.
-- If you are still on `@v1` or `@v1.2.x`, move to `@v3.1.2`. There is no
+  callers. The floating `@v3` tag is the recommended ref for both the
+  blocking-review and assistant callers — see "Prefer floating `@v3` over an
+  exact pin" above; that guidance is not scoped to one workflow.
+- If you are still on `@v1` or `@v1.2.x`, move to `@v3`. There is no
   interface change — the files are identical at equivalent commits.
 
 Note `dependabot-auto-merge` uses a **prefixed** namespace
@@ -406,8 +410,8 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association))
     # The v3 line, not v1: tags here are repo-wide, and v1 is frozen/deprecated.
-    # See "The v1 line is deprecated" under Versioning above.
-    uses: smartwatermelon/github-workflows/.github/workflows/claude-assistant.yml@v3.1.2
+    # Track floating @v3, not an exact @v3.x.y — see "Versioning" above.
+    uses: smartwatermelon/github-workflows/.github/workflows/claude-assistant.yml@v3
     secrets:
       claude_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 ```
@@ -418,11 +422,12 @@ Add `CLAUDE_CODE_OAUTH_TOKEN` to your repository or organization secrets.
 
 | Input | Type | Default | Description |
 | ----- | ---- | ------- | ----------- |
-| `allowed_tools` | string | `''` | Tool allowlist passed as `--allowed-tools`. Empty = action default policy. |
+| `allowed_tools` | string | `''` | Tool allowlist passed as `--allowed-tools`. Additive — see below. Empty = action default policy. |
+| `disallowed_tools` | string | `''` | Tool denylist passed as `--disallowed-tools`. Genuinely revokes. Empty = no denylist. |
 | `model` | string | `''` | Model ID passed as `--model`. Empty = action default model. |
 
-Both are optional. With both empty the workflow passes no `claude_args` at
-all, so behavior is identical to a caller that sets neither.
+All three are optional. With all three empty the workflow passes no
+`claude_args` at all, so behavior is identical to a caller that sets none.
 
 #### Restricting tools (recommended)
 
@@ -438,7 +443,7 @@ files in its checkout, so those are in scope — but grants only **read-only
 Read the additive-semantics note below before treating that as a guarantee:
 
 ```yaml
-    uses: smartwatermelon/github-workflows/.github/workflows/claude-assistant.yml@v3.1.2
+    uses: smartwatermelon/github-workflows/.github/workflows/claude-assistant.yml@v3
     with:
       allowed_tools: 'Read,Edit,Write,Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git rev-parse:*),Bash(git ls-files:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr list:*),Bash(gh pr comment:*),mcp__github_inline_comment__create_inline_comment'
       model: claude-opus-4-7
@@ -461,15 +466,29 @@ So `allowed_tools` can only **grant** tools on top of the action's baseline —
 it cannot revoke anything the action grants itself. It restores the ability to
 express a per-repo tool policy without inlining the action, and it keeps that
 policy visible in the caller stub, but do not read it as a hard sandbox.
-Revoking a tool requires `--disallowed-tools`, which this workflow does not yet
-expose; open an issue if you need it.
 
-Both inputs are validated before use. `model` must match
-`[a-zA-Z0-9._-]+`; `allowed_tools` is passed via `env:` (never interpolated
-into a `run:` line) and rejects quotes, backticks, `$`, `;`, `&`, `|`,
-backslashes, and newlines, so a caller cannot break out of the generated
-command line. Spaces are permitted because tool specs need them
-(`Bash(gh pr view:*)`), which is why the generated argument stays quoted.
+#### Revoking a tool: `disallowed_tools`
+
+Use `disallowed_tools` when you need an actual restriction. It emits
+`--disallowed-tools`, a real Claude Code CLI flag that `claude_args` passes
+through to. The deny list is applied to the resolved tool set, so it subtracts
+from the action's own tag-mode baseline as well as from anything
+`allowed_tools` added — a spec named in both is denied.
+
+```yaml
+    uses: smartwatermelon/github-workflows/.github/workflows/claude-assistant.yml@v3
+    with:
+      disallowed_tools: 'Bash(git push:*),Bash(gh pr merge:*),WebFetch'
+    secrets:
+      claude_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+```
+
+All three inputs are validated before use. `model` must match
+`[a-zA-Z0-9._-]+`; `allowed_tools` and `disallowed_tools` are passed via `env:`
+(never interpolated into a `run:` line) and reject quotes, backticks, `$`, `;`,
+`&`, `|`, backslashes, and newlines, so a caller cannot break out of the
+generated command line. Spaces are permitted because tool specs need them
+(`Bash(gh pr view:*)`), which is why the generated arguments stay quoted.
 
 There is deliberately **no free-form `claude_args` passthrough**: an opaque
 arg blob would let a caller pass flags that *widen* permissions, which is the

--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ Add `CLAUDE_CODE_OAUTH_TOKEN` to your repository or organization secrets.
 | Input | Type | Default | Description |
 | ----- | ---- | ------- | ----------- |
 | `allowed_tools` | string | `''` | Tool allowlist passed as `--allowed-tools`. Additive — see below. Empty = action default policy. |
-| `disallowed_tools` | string | `''` | Tool denylist passed as `--disallowed-tools`. Genuinely revokes. Empty = no denylist. |
+| `disallowed_tools` | string | `''` | Tool denylist passed as `--disallowed-tools`. Intended to revoke, but precedence is unverified — see below. Empty = no denylist. |
 | `model` | string | `''` | Model ID passed as `--model`. Empty = action default model. |
 
 All three are optional. With all three empty the workflow passes no
@@ -471,9 +471,16 @@ policy visible in the caller stub, but do not read it as a hard sandbox.
 
 Use `disallowed_tools` when you need an actual restriction. It emits
 `--disallowed-tools`, a real Claude Code CLI flag that `claude_args` passes
-through to. The deny list is applied to the resolved tool set, so it subtracts
-from the action's own tag-mode baseline as well as from anything
-`allowed_tools` added — a spec named in both is denied.
+through to.
+
+**Verify the effect before relying on it.** Unlike `allowed_tools` — whose
+additive behavior was confirmed by reading `claude-code-action` v1.0.193
+source — the precedence of `--disallowed-tools` against the tool set the
+action emits for itself in tag mode has *not* been verified here. A deny
+list is expected to subtract from the resolved set, but that expectation is
+exactly the kind of assumption that proved wrong for `allowed_tools`, which
+turned out to union rather than replace. Confirm with a live `@claude` run
+in a repo that sets this input, and treat it as unproven until you have.
 
 ```yaml
     uses: smartwatermelon/github-workflows/.github/workflows/claude-assistant.yml@v3


### PR DESCRIPTION
Closes #136, closes #137, closes #146. Refs #144.

## `disallowed_tools` (#146)

`allowed_tools` unions with claude-code-action's tag-mode baseline, so it can only ever grant. `disallowed_tools` emits `--disallowed-tools`, which is evaluated against the resolved tool set and therefore genuinely revokes — including tools the action's own baseline grants.

Mirrors the existing `allowed_tools` implementation exactly rather than inventing a second style:

- consumed via `env:`, never interpolated into the `run:` block
- newline check **before** the anchored charset check (a multi-line value could otherwise smuggle a bad line past a per-line `grep -qE '^…$'`)
- identical permitted charset
- quoted in the assembled args, because tool specs legitimately contain spaces
- empty default emits nothing

## `--model` quoting (#144)

`CLAUDE_ARGS="--model $MODEL"` was unquoted. Benign today — the charset validation excludes all whitespace — but quoted now for consistency with the two tool lists and to stay immune to future charset drift.

## README version-pin fixes (#136, #137)

**#136:** the blocking-review caller's block comment said "Pin to v3.1.0 or later" directly above a `uses: @v3` line telling the reader to track the floating tag. The Dependabot guidance it carries is still correct and still important — a caller-level `if:` leaves a required check permanently pending (#115/#117) — so that survives intact. The stale version-floor framing is replaced with a note that `@v3` already resolves to a commit containing the in-job skip, so there is no floor for the reader to enforce.

**#137:** all three `claude-assistant.yml@v3.1.2` examples now float on `@v3`, and the "v1 line is deprecated" prose states that the floating-tag recommendation covers both the blocking-review and assistant callers instead of endorsing an exact pin.

**Exact pins deliberately left exact:** the Versioning table (documents what specific immutable tags contain), the GHSA incident narrative (`@v3.1.0` is the specific pin that caused the miss), and the `@v3.1.2`/`@v1.2.6` tag-identity example. Those are documentation of specific tags, not recommendations.

## Verification

- `ruby -ryaml` parse: clean
- `bash -n` on the extracted validation step: clean
- `zizmor --config zizmor.yml`: no findings (3 suppressed)
- **Empty-input default proven unchanged** by running the extracted validation step from `HEAD` and from this commit across every combination of empty/non-empty `allowed_tools` and `model`. Identical output throughout; the only difference anywhere is the intentional `--model` quoting.
- 24 injection vectors — quotes, backticks, `$(...)`, `$VAR`, `;`, `|`, `&`, `&&`, backslash, newline, redirects, brace expansion, and the deliberately excluded `+`/`@` — all rejected for `disallowed_tools`, with parity against `allowed_tools`.
- A multi-line value whose first line is charset-valid is rejected, confirming the newline check runs first.

### Note on #148

The pre-push reviewer filed #148 suggesting the `--model` change embeds literal `\"` characters in the output. That is a misreading of bash source-level escaping. Verified against the actual bytes written to `$GITHUB_OUTPUT`:

```
c l a u d e _ a r g s = - - m o d e l   " c l a u d e - o p u s - 4 - 7 "  \n
```

Plain `"` characters — the same form `--allowed-tools` already emits and that `parseShellArgs` tokenizes as real shell quoting. No behavioral change.
