### PR TITLE
chore: close four tracked low-effort review issues

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,11 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "chore"
+    # Default is 5. Only 3 actions are tracked here today, so the cap is not
+    # currently reachable — this is headroom, not a fix for a live problem.
+    # It costs nothing, and the failure mode it forecloses is the one this
+    # file exists to prevent: a capped run queues the remaining bumps until
+    # next week, delaying a security fix in whatever got cut. Being upstream
+    # of ~30 repos is the same reason `cooldown` is omitted above — bumps
+    # here should not wait. See #127.
+    open-pull-requests-limit: 10

--- a/README.md
+++ b/README.md
@@ -230,6 +230,19 @@ The config encodes two documented policy decisions and nothing else:
 | `unpinned-uses` | `ref-pin` for `smartwatermelon/github-workflows/*`, strict `hash-pin` for everything else | Reflects the two-class policy above. Third-party findings stay visible. |
 | `excessive-permissions` | ignored for the three standard caller filenames | Those blocks are required by the reusable workflows; removing them causes `startup_failure`, not a narrower blast radius. |
 
+The `excessive-permissions` ignore list matches on **caller filename**, not on
+which reusable workflow the caller invokes. Use the standard names:
+
+| Caller filename | Calls |
+| --- | --- |
+| `claude-blocking-review.yml` | `claude-blocking-review.yml` |
+| `claude.yml` | `claude-assistant.yml` (note: the names differ) |
+| `dependabot-auto-merge.yml` | `dependabot-auto-merge.yml` |
+
+Name a caller anything else and zizmor reports `excessive-permissions` against
+it with no indication why. Either rename it to the standard filename or add
+your local name to the `ignore:` list in your copy of `zizmor.yml`.
+
 It is deliberately **not** a blanket mute. On a representative consumer it takes
 findings from 9 high to 2 — and the 2 that survive are genuine third-party
 actions pinned to floating majors in that repo's own workflows, which is a real

--- a/docs/plans/2026-03-06-centralize-claude-assistant.md
+++ b/docs/plans/2026-03-06-centralize-claude-assistant.md
@@ -1,6 +1,12 @@
 # Centralize Claude Assistant Workflow
 
 > **Status: COMPLETE** — All tasks done as of 2026-03-09. See "Post-deployment fixes" below for lessons learned.
+>
+> **Historical document.** Code snippets below are point-in-time records of what
+> was built in March 2026, not current configuration. Pinned action SHAs in
+> particular are deliberately NOT updated as Dependabot bumps them — the live
+> pins are in `.github/workflows/`, which is the only place to read them from.
+> See #124.
 
 **Goal:** Extract the Claude Code Action invocation into a reusable `workflow_call` workflow so all 10 repos share one implementation, keeping the security-critical `author_association` guard as a thin per-repo caller.
 

--- a/nightowl-restore-blocking-review.sh
+++ b/nightowl-restore-blocking-review.sh
@@ -50,10 +50,23 @@ mkdir -p "$WORK_DIR"
 # Enumerate active NightOwl repos dynamically (excludes archived, .github,
 # and any repo in .claude-review-ignore). Using dynamic discovery so a repo
 # added in the last hours isn't silently skipped.
+# Declare before mapfile so the array exists unconditionally, matching the
+# ALL_REPOS handling below. mapfile does declare an empty array even when its
+# input is empty (verified), so this is belt-and-braces rather than a fix for
+# a live unbound-variable path -- but it makes the invariant independent of
+# that bash subtlety, which is what the loop below relies on under `set -u`.
+IGNORED=()
 mapfile -t IGNORED < <(grep -v '^#' "$IGNORE_FILE" 2>/dev/null | grep -v '^$' || true)
 is_ignored() {
   local repo="$1"
-  for i in "${IGNORED[@]:-}"; do
+  # Return early rather than looping over "${IGNORED[@]:-}": on an empty array
+  # that expands to a single empty string, not to nothing, so the loop ran one
+  # spurious iteration with i="". Never a false positive (no repo is named "")
+  # but wrong, and the `:-` obscured that the array is always set. See #139.
+  if [[ ${#IGNORED[@]} -eq 0 ]]; then
+    return 1
+  fi
+  for i in "${IGNORED[@]}"; do
     [[ "$i" == "${ORG}/${repo}" ]] && return 0
   done
   return 1

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -80,8 +80,16 @@ rules:
   # Scoped to the three standard caller filenames only. A repo's own
   # workflows are still audited normally — if `validate.yml` or `release.yml`
   # asks for more than it needs, that finding still fires.
+  #
+  # These match on FILENAME, not on which reusable workflow is called, so the
+  # coupling is by naming convention. Note especially that `claude.yml` is the
+  # caller for `claude-assistant.yml` — the names differ, which is easy to
+  # misread as an omission. A consumer who names a caller anything else (say
+  # `claude-assistant-caller.yml`) gets excessive-permissions findings with no
+  # explanation; the fix is to rename the caller to the standard filename, or
+  # to add the local name here. See #142 and the README's zizmor section.
   excessive-permissions:
     ignore:
-      - claude-blocking-review.yml
-      - claude.yml
-      - dependabot-auto-merge.yml
+      - claude-blocking-review.yml # caller for claude-blocking-review.yml
+      - claude.yml # caller for claude-assistant.yml
+      - dependabot-auto-merge.yml # caller for dependabot-auto-merge.yml


### PR DESCRIPTION
Batch of four small, independent fixes from the non-blocking review backlog. No workflow logic changes; the only code change is in a maintenance script.

## Fixed

| Issue | Change |
| --- | --- |
| #127 | `open-pull-requests-limit: 10` in `dependabot.yml` |
| #139 | `is_ignored()` empty-array guard in `nightowl-restore-blocking-review.sh` |
| #142 | Documented the zizmor caller-**filename** coupling (`zizmor.yml` + README table) |
| #124 | Marked the completed plan doc point-in-time instead of chasing live pins |

## Triage: three of the seven open issues needed no code

**#150 is a false finding — no change made.** It claims `^[a-zA-Z0-9_,:*()./ -]+$` contains a space-to-hyphen range admitting `"`, `$`, `&`, `'`. It does not: a hyphen immediately before `]` is a literal, not a range. Verified against known-bad cases — the regex rejects `"` `$` `&` `'` `;` `|` `` ` `` `\` `+` `@` and accepts `Read,Bash(git status:*)`, exactly as its error message claims. "Fixing" this would have churned a correct security check on a bad report. Recommend closing as invalid.

**#133 is already fixed** by c777455, which added the GitHub-API-outage diagnosis its main suggestion asked for. The remaining suggestions are upstream (a `claude-code-action` retry-policy gap) or open policy questions, not changes to this repo.

**#151 was settled** by #152 and is recorded as verified.

## Verification

Both local reviewers ran; the adversarial reviewer initially flagged the #139 change as a `set -u` regression, on the theory that `mapfile` leaves the array unset when its input is empty. **That premise is false** — `mapfile` declares an empty array either way, confirmed including the real missing-ignore-file path — so there was no live unbound-variable break. The recommended `IGNORED=()` initialization is kept anyway, because it makes the invariant independent of that bash subtlety rather than reliant on it, and matches the `ALL_REPOS` pattern directly below it.

The #142 change looked cosmetic but was the highest-stakes one: trailing `#` comments on ignore-list entries could plausibly have been parsed into the filename strings, which would mean fleet-wide false positives. A clean run alone proves nothing here, so it was checked against a known-bad control — `permissions: write-all` under a non-ignored filename fires `excessive-permissions` at high severity, and the identical file named `claude.yml` reports it ignored (0 high) under **both** the old and new config. Behavior-preserving, proven.

Also: `shellcheck -S info` clean, `yamllint` clean, `zizmor` clean, and the #139 fix tested under `set -euo pipefail` using the script's actual call-site idiom across missing-file, empty, matching, and non-matching cases.

Closes #124, #127, #139, #142

https://claude.ai/code/session_01PewW1Ha7bBtne9V72XjdsJ
