### PR TITLE
fix(standards): say why the base-SHA fetch failed, not just that it did

### DIFF
--- a/.github/workflows/standards-check.yml
+++ b/.github/workflows/standards-check.yml
@@ -134,11 +134,15 @@ jobs:
               exit 0
               ;;
           esac
-          if git -C repo fetch --depth=1 origin "${BASE_SHA}" 2>/dev/null; then
+          # Capture stderr rather than discarding it: a fallback that cannot
+          # say WHY it fired is a rate you can only sample, not a fault you can
+          # diagnose. Keep it to one line so the annotation stays readable.
+          if fetch_err=$(git -C repo fetch --depth=1 origin "${BASE_SHA}" 2>&1); then
             echo "changed_since=${BASE_SHA}" >> "${GITHUB_OUTPUT}"
             echo "scoping to files changed since ${BASE_SHA}"
           else
-            echo "::warning::could not fetch base ${BASE_SHA}; falling back to whole-repo sweep"
+            fetch_err=$(printf '%s' "${fetch_err}" | tr '\n' ' ' | tr -s ' ')
+            echo "::warning::could not fetch base ${BASE_SHA}; falling back to whole-repo sweep — git said: ${fetch_err}"
           fi
 
       - name: Resolve the standards SHA


### PR DESCRIPTION
The fallback warning discarded git's stderr (`2>/dev/null`), so a run that fell back to a whole-repo sweep reported **that** it happened and never **why**. That turns a diagnosable fault into a rate you can only sample.

```diff
-          if git -C repo fetch --depth=1 origin "${BASE_SHA}" 2>/dev/null; then
+          if fetch_err=$(git -C repo fetch --depth=1 origin "${BASE_SHA}" 2>&1); then
```

...and the else branch appends `git said: ${fetch_err}`, collapsed to one line so the annotation stays readable.

## Why this is safe under `set -euo pipefail`

`fetch_err=$(...)` used as an `if` condition is exempt from `-e`, so a failed fetch takes the else branch rather than aborting the step.

**Validated against a known-bad case** rather than assumed — an unreachable SHA with no `origin` configured:

```
::warning::could not fetch base deadbeef...; falling back to whole-repo sweep — git said: fatal: 'origin' does not appear to be a git repository fatal: Could not read from remote repository. ...
reached end, exit code preserved
script rc=0
```

## Context

Found while re-measuring the fallback rate, which turned out to be **zero** rather than the previously reported ~27% (see smartwatermelon/dev-env#121). This is the one real gap that survived that correction. It is a diagnostics fix, **not** a W3 blocker.

## Note on rollout

This does not reach any caller until `@standards-check-v1` is moved to the merge commit — a deliberate manual step, not part of this PR.

## Checks

`yamllint` clean · `zizmor` no findings · code-reviewer PASS · adversarial-reviewer PASS

https://claude.ai/code/session_01ESsw699T54JHARkQXrdL3o