### PR TITLE
fix(standards): stop passing a stray empty argument when scope is unset

### DIFF
--- a/.github/workflows/standards-check.yml
+++ b/.github/workflows/standards-check.yml
@@ -236,6 +236,11 @@ jobs:
           # entirely rather than passed with an empty value — the script
           # treats an unresolvable ref as a hard error, which is correct for a
           # typo'd ref but wrong for "no narrowing requested".
+          # "${scope_args[@]-}" expands an EMPTY array to one empty-string
+          # argument, not to nothing, which run-standards.sh then rejects via
+          # its catch-all `*)` branch as `unknown argument: `. Plain
+          # "${scope_args[@]}" expands to nothing when empty and is safe under
+          # `set -u` on bash 4.4+ (runners are bash 5.x).
           scope_args=()
           [ -n "${CHANGED_SINCE}" ] && scope_args+=(--changed-since "${CHANGED_SINCE}")
           bash standards-src/standards/run-standards.sh \
@@ -243,4 +248,4 @@ jobs:
             --config-dir standards-src/standards \
             --skip "${skip_list}" \
             --node-floor "${NODE_FLOOR}" \
-            "${scope_args[@]-}"
+            "${scope_args[@]}"

--- a/tests/test-run-standards.sh
+++ b/tests/test-run-standards.sh
@@ -159,5 +159,44 @@ else
   _bad "--changed-since bad ref exited ${rc}, expected 2 (see ${tmp}/cs-badref.log)"
 fi
 
+# The workflow builds the optional --changed-since flag in an array and
+# expands it at the call site. "${arr[@]-}" expands an EMPTY array to one
+# empty-string argument rather than to nothing, which lands on the runner's
+# catch-all `*)` branch as `unknown argument: ` and exits 2 — so a repo that
+# skips no linters and requests no narrowing fails the whole check. Assert the
+# expansion form the workflow actually uses passes no stray argument.
+# This asserts on argument assembly only, so it does not depend on the linters
+# being installed — it counts what the call site would pass, without running a
+# real lint. The workflow's own expansion form is reproduced verbatim.
+_argc_for() { # $1 = expansion form, literally as written in the workflow
+  bash -c '
+    set -euo pipefail
+    scope_args=()
+    CHANGED_SINCE=""
+    [ -n "${CHANGED_SINCE}" ] && scope_args+=(--changed-since "${CHANGED_SINCE}")
+    set -- --skip "" --node-floor 22 '"$1"'
+    echo "$#"
+  '
+}
+# Built from a literal dollar rather than written inline, so the expansion
+# forms under test stay unexpanded here without tripping SC2016.
+d='\044'
+fixed_form="$(printf '"%b{scope_args[@]}"' "${d}")"
+broken_form="$(printf '"%b{scope_args[@]-}"' "${d}")"
+fixed_argc="$(_argc_for "${fixed_form}")"
+broken_argc="$(_argc_for "${broken_form}")"
+if [[ "${fixed_argc}" -eq 4 ]]; then
+  _ok "empty scope_args expands to nothing (no stray empty argument)"
+else
+  _bad "empty scope_args expanded to ${fixed_argc} args, expected 4"
+fi
+# Guard the test itself: the form this replaced must still be detectably wrong,
+# so a future refactor cannot make this assertion vacuous.
+if [[ "${broken_argc}" -eq 5 ]]; then
+  _ok "known-bad expansion form is still detected as passing a stray argument"
+else
+  _bad "known-bad expansion form no longer reproduces; this test proves nothing"
+fi
+
 echo "${pass} passed, ${fail} failed"
 [[ "${fail}" -eq 0 ]]


### PR DESCRIPTION
## The bug

`"${scope_args[@]-}"` expands an **empty** array to one empty-string argument, not to nothing. `run-standards.sh` hits that empty string in its catch-all `*)` branch and exits 2:

```
skip list: ''
##[error]unknown argument:
##[error]Process completed with exit code 2.
```

So `standards-check` fails on any repo that requests no `changed-since` narrowing — that is, every repo running in whole-repo hygiene mode.

## Why it matters now

`standards-check / run-standards-check` is the sole required check on `dev-env`, `claude-config`, `dotfiles` and `github-workflows` after today's protection change. While this is broken, those repos cannot merge anything.

Surfaced on `nightowlstudiollc/reliquarist#93-96`, which went from green to failing after a rebase onto current `main`. Not specific to those PRs, and not a Dependabot problem.

## What is not the cause

`--skip ""` is fine. `run-standards.sh` parses `--skip) skip="$2"` and accepts an empty value without complaint — verified by running the real runner directly. The stray argument from the array expansion is the whole story.

## The fix

Plain `"${scope_args[@]}"`, which expands to nothing when empty and is safe under `set -u` on bash 4.4+ (runners are bash 5.x). Both forms are identical when the array is non-empty, so narrowing behaviour is unchanged.

The file already solved this exact problem for `--changed-since` at lines 235-240 — omit the flag rather than pass it empty. This applies the same discipline at the call site.

## Verification

Ran the real runner with both expansion forms, counting `unknown argument` hits:

| Expansion | Hits |
| --- | --- |
| `"${scope_args[@]-}"` (old) | 1 |
| `"${scope_args[@]}"` (new) | 0 |

## The test

Asserts on **argument assembly**, not lint output, so it does not depend on linters being installed.

It carries a paired assertion that the known-bad form still reproduces. Without that, a future refactor could make the first assertion vacuous and the suite would stay green over a reintroduced bug. My first attempt at this test passed against the broken code — it is included in the form that actually fails against it.

`17 passed, 0 failed`. shellcheck `-S info` clean, no disable directives.

https://claude.ai/code/session_01ESsw699T54JHARkQXrdL3o
